### PR TITLE
Add bindings for ign-msgs and a mock-up of ign-transport

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,16 @@
+# Enable logging rc options.
+common --announce_rc
+
+# Enable verbose failures for testing only.
+build --verbose_failures
+
+# Compiler options.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
+
+# Enable logging error output.
+test --test_output=errors
+test --test_summary=detailed
+
+# Enable use_fast_cpp_protos when using C++ implementation and py_proto_library
+build --define use_fast_cpp_protos=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bazel-bin
+bazel-out
+bazel-python-ignition
+bazel-testlogs
+build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/pybind11_protobuf"]
+	path = external/pybind11_protobuf
+	url = https://github.com/pybind/pybind11_protobuf.git
+[submodule "external/protobuf"]
+	path = external/protobuf
+	url = https://github.com/protocolbuffers/protobuf.git

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
+
+#------------------------------------------------
+# C++ library
+
+cc_library(
+  name = "ignition_msgs_lib",
+  srcs = ["src/ignition_msgs.cc"],
+  hdrs = ["include/ignition_msgs.hh"],
+  includes = ["include"],
+  deps = [
+      "@ign-msgs9//:time_cc_proto",
+      "@ign-msgs9//:topic_info_cc_proto",
+      "@ign-msgs9//:wrench_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# C++ binary
+
+cc_binary(
+  name = "main",
+  srcs = ["src/main.cc"],
+  includes = ["include"],
+  deps = [
+      "//:ignition_msgs_lib",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# Python C++ extension module
+
+pybind_extension(
+  name = "ignition_msgs",
+  srcs = ["src/pybind11/ignition_msgs.cc"],
+  includes = ["include"],
+  deps = [
+      "//:ignition_msgs_lib",
+      "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+      "@com_google_protobuf//:protobuf",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+pybind_extension(
+  name = "ignition_transport",
+  srcs = ["src/pybind11/ignition_transport.cc"],
+  includes = ["include"],
+  deps = [
+      "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+      "@com_google_protobuf//:protobuf",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+project(protobuf_example)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+#============================================================================
+# Find protobuf
+# 
+# macOS: $ brew install protobuf
+# 
+find_package(Protobuf REQUIRED)
+
+#============================================================================
+# Find google abseil
+# 
+# macOS: $ brew install abseil
+# 
+find_package(absl REQUIRED)
+
+#============================================================================
+# Find pybind11
+# 
+# macOS: $ brew install python
+# macOS: $ brew install pybind11
+# 
+find_package(Python COMPONENTS Interpreter Development)
+find_package(pybind11 CONFIG)
+
+#============================================================================
+# subdirectories for external dependencies and protobuf definitions
+
+add_subdirectory(external)
+add_subdirectory(proto)
+
+#============================================================================
+# msgs_tools
+
+add_library(msgs_tools src/msgs_tools.cc)
+
+target_link_libraries(msgs_tools ign_proto ${PROTOBUF_LIBRARY})
+
+target_include_directories(msgs_tools
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/include
+    ${Protobuf_INCLUDE_DIR}
+)
+
+#============================================================================
+# ignition_msgs Python extension module
+
+pybind11_add_module(msgs_tools_module MODULE
+  src/pybind11/msgs_tools_module.cc
+)
+
+target_include_directories(msgs_tools_module
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROTOBUF_INCLUDE_DIR}
+)
+  
+target_link_libraries(msgs_tools_module
+  PRIVATE
+    pybind11_native_proto_caster
+    pybind11_proto
+    pybind11_proto_utils
+    pybind11_proto_cast_util
+    ign_proto
+    msgs_tools
+)
+
+add_dependencies(msgs_tools_module msgs_tools)
+
+#============================================================================
+# main
+
+add_executable(main src/main.cc)
+
+target_link_libraries(main ign_proto msgs_tools ${PROTOBUF_LIBRARY})
+
+target_include_directories(main
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/include
+    ${Protobuf_INCLUDE_DIR}
+)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Software License Agreement (Apache License)
+
+Copyright 2022 Rhys Mainwaring
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# Python Ignition
+
+This project aims to provide Python bindings for [`ignition-msgs`](https://github.com/ignitionrobotics/ign-msgs) and [`ignition-transport`](https://github.com/ignitionrobotics/ign-transport). It is a work in progress...
+
+C++ and Python libraries for [`ignition-msgs`](https://github.com/ignitionrobotics/ign-msgs) are generated using [Protobuf and gRPC rules for Bazel](https://rules-proto-grpc.com/en/latest/index.html).
+
+The objective is to generate Python bindings for [`ignition-transport`](https://github.com/ignitionrobotics/ign-transport) using [`pybind11`](https://github.com/pybind/pybind11). Interoperability between native Python protobuf
+libraries and the C++ protobuf library used in the [`pybind11`](https://github.com/pybind/pybind11) extension module is provided by [`pybind11_protobuf`](https://github.com/pybind/pybind11_protobuf).
+
+### Status
+
+- Working bindings for a selection of [`ignition-msgs`](https://github.com/ignitionrobotics/ign-msgs) are available using the protocol buffers native Python implementation. The build rules for the C++ implementation are also available however there is an open issue in [`pybind11_protobuf`](https://github.com/pybind/pybind11_protobuf) that prevents full interoperability in this case (see Notes below).
+- Bindings for [`ignition-transport`](https://github.com/ignitionrobotics/ign-transport) are in development. A mock-up of the main interfaces is provided that illustrates the proposed approach.
+
+## Install: macOS
+
+Install [Bazel](https://bazel.build/) and the [Google protocol buffers compiler](https://github.com/protocolbuffers/protobuf) using brew:
+
+```bash
+$ brew install bazel protobuf
+```
+
+Check the installed versions (`protobuf` must be version `3.19`):
+
+```bash
+$ protoc --version
+libprotoc 3.19.1
+
+$ bazel --version
+bazel 4.2.2-homebrew
+```
+
+Build everything
+
+```bash
+$ bazel build //...
+```
+
+## Usage
+
+The Bazel build file `ign-msgs8=9.BUILD` defines targets for a selection of messages.
+For example the targets for `proto/ignition/msgs/time.proto` are:
+
+```bash
+# proto_library
+@ign-msgs9//:time_proto
+
+# cpp_proto_library
+@ign-msgs9//:time_cc_proto
+
+# python_proto_library
+@ign-msgs9//:time_py_pb2
+```
+
+### `C++`
+
+To use the bindings in C++:
+
+```c++
+// main.cc
+#include "ignition/msgs/time.pb.h"
+#include <iostream>
+
+int main(int argc, const char* argv[])
+{
+  ignition::msgs::Time msg;
+  msg.set_sec(11);
+  msg.set_nsec(25);
+  std::cout << msg.DebugString();
+  
+  return 0;
+}
+```
+
+```bash
+# BUILD.bazel
+cc_binary(
+  name = "main",
+  srcs = ["main.cc"],
+  deps = [
+      "@ign-msgs9//:time_cc_proto",
+  ],
+)
+```
+
+### Python
+
+To use the bindings in Python:
+
+```python
+# example.py
+from ignition.msgs.time_pb2 import Time
+
+msg = Time()
+msg.sec = 15
+msg.nsec = 21
+print(msg)
+```
+
+```bash
+# BUILD.bazel
+
+py_binary(
+  name = "example",
+  srcs = ["example.py"],
+  data = [
+    "@com_google_protobuf//:proto_api",
+  ],
+  deps = [
+    "@ign-msgs9//:time_py_pb2",
+  ],
+)
+```
+
+## Examples
+
+There are C++ and Python examples:
+
+- `src/main.cc` an example using the C++ protobuf library.
+- `python/ign_proto_example` an example using the Python protobuf library.
+- `python/ign_msgs_example` an example using the Python protobuf library and a simple extenson module with functions that accept and return `ignition-msgs`.
+- `python/ign_transport_example` an example using the Python protobuf library and an
+extenson module with a mock-up of the `ignition.transport::Node` interface.
+
+## Notes and Issues
+
+### `protoc` version
+
+This version uses protoc version 3.19.1. You must ensure that the version of `protoc` installed by brew matches (otherwise the examples will segfault).
+
+```bash
+$ protoc --version
+libprotoc 3.19.1
+```
+
+### Protobuf generated Python libraries
+
+There are some issues when using the C++ implementation of the generated
+Python protobuf library. The brew installation of `protobuf` will default to
+use the C++ implementation, to enable the Python implementation set the environment variable
+
+```bash
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+```
+
+before building the project.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,121 @@
+workspace(name = "python-ignition")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
+# `abseil-cpp` required by `pybind11_protobuf`
+http_archive(
+    name = "com_google_absl",
+    sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",  # SHARED_ABSL_SHA
+    strip_prefix = "abseil-cpp-20211102.0",
+    urls = [
+        "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
+    ],
+)
+
+# `pybind11_bazel`
+http_archive(
+  name = "pybind11_bazel",
+  strip_prefix = "pybind11_bazel-72cbbf1fbc830e487e3012862b7b720001b70672",
+  sha256 = "516c1b3a10d87740d2b7de6f121f8e19dde2c372ecbfe59aef44cd1872c10395",
+  urls = ["https://github.com/pybind/pybind11_bazel/archive/72cbbf1fbc830e487e3012862b7b720001b70672.tar.gz"],
+)
+
+# `pybind11`
+http_archive(
+  name = "pybind11",
+  build_file = "@pybind11_bazel//:pybind11.BUILD",
+  strip_prefix = "pybind11-2.9.0",
+  sha256 = "057fb68dafd972bc13afb855f3b0d8cf0fa1a78ef053e815d9af79be7ff567cb",
+  urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.9.0.tar.gz"],
+)
+
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+python_configure(name = "local_config_python")
+
+# `pybind11_protobuf`
+git_repository(
+    name = "pybind11_protobuf",
+    commit = "30f02dd9ccd2fc7046c36ed913ed510fd1aa7301", # Latest (2022-01-05)
+    remote = "https://github.com/pybind/pybind11_protobuf.git",
+)
+
+# proto_library, cc_proto_library, and java_proto_library rules implicitly
+# depend on @com_google_protobuf for protoc and proto runtimes.
+# This statement defines the @com_google_protobuf repo.
+# 
+# The patch is required for @pybind11_protobuf//:pybind11_protobuf:proto_cast_util
+# 
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422",
+    strip_prefix = "protobuf-3.19.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz"],
+    patches = [
+        "com_google_protobuf_build.patch",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
+
+# GRPC v1.42, for proto rules.
+# For a related discussion of the pro/cons of various open-source py proto rule
+# repositories, see b/189457935.
+# http_archive(
+#     name = "com_github_grpc_grpc",
+#     sha256 = "9f387689b7fdf6c003fd90ef55853107f89a2121792146770df5486f0199f400",
+#     strip_prefix = "grpc-1.42.0",
+#     urls = ["https://github.com/grpc/grpc/archive/v1.42.0.zip"],
+# )
+
+# load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+# grpc_deps()
+
+# Protobuf and gRPC rules for Bazel
+# https://rules-proto-grpc.com/en/latest/index.html
+http_archive(
+    name = "rules_proto_grpc",
+    sha256 = "507e38c8d95c7efa4f3b1c0595a8e8f139c885cb41a76cab7e20e4e67ae87731",
+    strip_prefix = "rules_proto_grpc-4.1.1",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.1.1.tar.gz"],
+)
+
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains", "rules_proto_grpc_repos")
+rules_proto_grpc_toolchains()
+rules_proto_grpc_repos()
+
+load("@rules_proto_grpc//cpp:repositories.bzl", "cpp_repos")
+cpp_repos()
+
+load("@rules_proto_grpc//python:repositories.bzl", rules_proto_grpc_python_repos = "python_repos")
+rules_proto_grpc_python_repos()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
+# required when using --define use_fast_cpp_protos=true
+bind(
+    name = "python_headers",
+    actual = "@local_config_python//:python_headers",
+)
+
+# `ign-msgs9`
+# https://stackoverflow.com/questions/50592846/pull-github-repository-using-bazel
+# strip the `proto` prefix so that generated protobuf bindings for ignition-msgs
+# have the correct include path which is `ignition.msgs`
+new_git_repository(
+    name = "ign-msgs9",
+    commit = "6da277056e867e8b60c0b48ff88df9b3c5a49c9a", # Latest (2022-01-01)
+    remote = "https://github.com/ignitionrobotics/ign-msgs.git",
+    strip_prefix = "proto",
+    build_file = "//:ign-msgs9.BUILD"
+)
+
+# `ign-transport12`
+git_repository(
+    name = "ign-transport12",
+    commit = "185961ff1c97583c50d67c65a5b0c9bb9c64f5d5", # Latest (2022-01-01)
+    remote = "https://github.com/ignitionrobotics/ign-transport.git",
+)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(pybind11_protobuf)

--- a/external/com_google_protobuf_build.patch
+++ b/external/com_google_protobuf_build.patch
@@ -1,0 +1,10 @@
+--- BUILD
++++ BUILD
+@@ -993,6 +993,7 @@
+         "//conditions:default": [],
+         ":use_fast_cpp_protos": ["//external:python_headers"],
+     }),
++    visibility = ["//visibility:public"],
+ )
+
+ config_setting(

--- a/ign-msgs9.BUILD
+++ b/ign-msgs9.BUILD
@@ -1,0 +1,587 @@
+#------------------------------------------------
+# BUILD file for ign-msgs9
+#
+# Using https://rules-proto-grpc.com
+#
+# C++
+# https://rules-proto-grpc.com/en/latest/example.html
+#
+# Python 
+# https://rules-proto-grpc.com/en/latest/lang/python.html
+#
+# Notes: python_proto_library
+#  - Use output_mode = "NO_PREFIX" to use only the protobuf
+#    import path ignition.msgs. The default PREFIX will place
+#    each Python protobuf library under an extra folder with
+#    the target name.
+# 
+
+# load("@com_github_grpc_grpc//bazel:python_rules.bzl", "python_proto_library")
+# load("@com_google_protobuf//:protobuf.bzl", "python_proto_library")
+
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
+load("@rules_proto_grpc//python:defs.bzl", "python_proto_library")
+
+#------------------------------------------------
+# time.proto
+proto_library(
+  name = "time_proto",
+  srcs = ["ignition/msgs/time.proto"],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "time_cc_proto",
+  protos = [":time_proto"],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "time_py_pb2",
+  protos = [":time_proto"],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+ )
+
+#------------------------------------------------
+# header.proto
+proto_library(
+  name = "header_proto",
+  srcs = ["ignition/msgs/header.proto"],
+  deps = [":time_proto"],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "header_cc_proto",
+  protos = [":header_proto"],
+  deps = [
+    ":time_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "header_py_pb2",
+  protos = [":header_proto"],
+  deps = [
+    ":time_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# cmd_vel2d.proto
+proto_library(
+  name = "cmd_vel2d_proto",
+  srcs = ["ignition/msgs/cmd_vel2d.proto"],
+  deps = [
+    ":header_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "cmd_vel2d_cc_proto",
+  protos = [":cmd_vel2d_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "cmd_vel2d_py_pb2",
+  protos = [":cmd_vel2d_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# double.proto
+proto_library(
+  name = "double_proto",
+  srcs = ["ignition/msgs/double.proto"],
+  deps = [
+    ":header_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "double_cc_proto",
+  protos = [":double_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "double_py_pb2",
+  protos = [":double_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+# #------------------------------------------------
+# double_v.proto
+proto_library(
+  name = "double_v_proto",
+  srcs = ["ignition/msgs/double_v.proto"],
+  deps = [
+    ":header_proto",
+    ":double_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "double_v_cc_proto",
+  protos = [":double_v_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":double_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "double_v_py_pb2",
+  protos = [
+    ":double_v_proto",
+  ],
+  deps = [
+    ":header_py_pb2",
+    ":double_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# float.proto
+proto_library(
+  name = "float_proto",
+  srcs = ["ignition/msgs/float.proto"],
+  deps = [
+    ":header_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "float_cc_proto",
+  protos = [":float_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "float_py_pb2",
+  protos = [":float_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# float_v.proto
+proto_library(
+  name = "float_v_proto",
+  srcs = ["ignition/msgs/float_v.proto"],
+  deps = [
+    ":header_proto",
+    ":float_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "float_v_cc_proto",
+  protos = [":float_v_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":float_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "float_v_py_pb2",
+  protos = [":float_v_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":float_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# pid.proto
+proto_library(
+  name = "pid_proto",
+  srcs = ["ignition/msgs/pid.proto"],
+  deps = [
+    ":header_proto",
+    ":double_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "pid_cc_proto",
+  protos = [":pid_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":double_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "pid_py_pb2",
+  protos = [":pid_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":double_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# quaternion.proto
+proto_library(
+  name = "quaternion_proto",
+  srcs = ["ignition/msgs/quaternion.proto"],
+  deps = [
+    ":header_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "quaternion_cc_proto",
+  protos = [":quaternion_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "quaternion_py_pb2",
+  protos = [":quaternion_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# vector3d.proto
+proto_library(
+  name = "vector3d_proto",
+  srcs = ["ignition/msgs/vector3d.proto"],
+  deps = [
+    ":header_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "vector3d_cc_proto",
+  protos = [":vector3d_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "vector3d_py_pb2",
+  protos = [":vector3d_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# pose.proto
+proto_library(
+  name = "pose_proto",
+  srcs = ["ignition/msgs/pose.proto"],
+  deps = [
+    ":header_proto",
+    ":quaternion_proto",
+    ":vector3d_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "pose_cc_proto",
+  protos = [":pose_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":quaternion_cc_proto",
+    ":vector3d_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "pose_py_pb2",
+  protos = [":pose_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":quaternion_py_pb2",
+    ":vector3d_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# pose_v.proto
+proto_library(
+  name = "pose_v_proto",
+  srcs = ["ignition/msgs/pose_v.proto"],
+  deps = [
+    ":header_proto",
+    ":pose_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "pose_v_cc_proto",
+  protos = [":pose_v_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":pose_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "pose_v_py_pb2",
+  protos = [":pose_v_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":pose_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# twist.proto
+proto_library(
+  name = "twist_proto",
+  srcs = ["ignition/msgs/twist.proto"],
+  deps = [
+    ":header_proto",
+    ":vector3d_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "twist_cc_proto",
+  protos = [":twist_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":vector3d_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "twist_py_pb2",
+  protos = [":twist_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":vector3d_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# wrench.proto
+proto_library(
+  name = "wrench_proto",
+  srcs = ["ignition/msgs/wrench.proto"],
+  deps = [
+    ":header_proto",
+    ":vector3d_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "wrench_cc_proto",
+  protos = [":wrench_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":vector3d_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "wrench_py_pb2",
+  protos = [":wrench_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":vector3d_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# publish.proto
+proto_library(
+    name = "publish_proto",
+    srcs = ["ignition/msgs/publish.proto"],
+    deps = [
+      ":header_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "publish_cc_proto",
+  protos = [":publish_proto"],
+  deps = [
+    ":header_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "publish_py_pb2",
+  protos = [":publish_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# publishers.proto
+proto_library(
+  name = "publishers_proto",
+  srcs = ["ignition/msgs/publishers.proto"],
+  deps = [
+    ":header_proto",
+    ":publish_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "publishers_cc_proto",
+  protos = [":publishers_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":publish_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "publishers_py_pb2",
+  protos = [":publishers_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":publish_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# subscribe.proto
+proto_library(
+  name = "subscribe_proto",
+  srcs = ["ignition/msgs/subscribe.proto"],
+  deps = [
+    ":header_proto"
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "subscribe_cc_proto",
+  protos = [":subscribe_proto"],
+  deps = [
+    ":header_cc_proto"
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "subscribe_py_pb2",
+  protos = [":subscribe_proto"],
+  deps = [
+    ":header_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)
+
+#------------------------------------------------
+# topic_info.proto
+proto_library(
+  name = "topic_info_proto",
+  srcs = ["ignition/msgs/topic_info.proto"],
+  deps = [
+    ":header_proto",
+    ":publish_proto",
+    ":subscribe_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+cpp_proto_library(
+  name = "topic_info_cc_proto",
+  protos = [":topic_info_proto"],
+  deps = [
+    ":header_cc_proto",
+    ":publish_cc_proto",
+    ":subscribe_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+python_proto_library(
+  name = "topic_info_py_pb2",
+  protos = [":topic_info_proto"],
+  deps = [
+    ":header_py_pb2",
+    ":publish_py_pb2",
+    ":subscribe_py_pb2",
+  ],
+  output_mode = "NO_PREFIX",
+  visibility = ["//visibility:public"],
+)

--- a/include/ignition_msgs.hh
+++ b/include/ignition_msgs.hh
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Rhys Mainwaring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef PYTHON_IGNITION_MSGS_HH
+#define PYTHON_IGNITION_MSGS_HH
+
+#include "ignition/msgs/time.pb.h"
+#include "ignition/msgs/topic_info.pb.h"
+#include "ignition/msgs/wrench.pb.h"
+
+ignition::msgs::Time MakeTime();
+
+void TakeTime(const ignition::msgs::Time& msg);
+
+void TakeTopicInfo(const ignition::msgs::TopicInfo& msg);
+
+void TakeWrench(const ignition::msgs::Wrench& msg);
+
+#endif

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,0 +1,64 @@
+#------------------------------------------------
+# Python examples
+
+py_binary(
+  name = "ign_proto_example",
+  srcs = ["ign_proto_example.py"],
+  deps = [
+    "@ign-msgs9//:header_py_pb2",
+    "@ign-msgs9//:cmd_vel2d_py_pb2",
+    "@ign-msgs9//:double_py_pb2",
+    "@ign-msgs9//:double_v_py_pb2",
+    "@ign-msgs9//:float_py_pb2",
+    "@ign-msgs9//:float_v_py_pb2",
+    "@ign-msgs9//:pid_py_pb2",
+    "@ign-msgs9//:pose_py_pb2",
+    "@ign-msgs9//:pose_v_py_pb2",
+    "@ign-msgs9//:quaternion_py_pb2",
+    "@ign-msgs9//:time_py_pb2",
+    "@ign-msgs9//:twist_py_pb2",
+    "@ign-msgs9//:vector3d_py_pb2",
+    "@ign-msgs9//:wrench_py_pb2",
+    "@ign-msgs9//:publish_py_pb2",
+    "@ign-msgs9//:publishers_py_pb2",
+    "@ign-msgs9//:subscribe_py_pb2",
+    "@ign-msgs9//:topic_info_py_pb2",
+  ],
+)
+
+py_binary(
+  name = "ign_msgs_example",
+  srcs = ["ign_msgs_example.py"],
+  data = [
+    "//:ignition_msgs.so",
+    "@com_google_protobuf//:proto_api",
+  ],
+  deps = [
+    "@ign-msgs9//:header_py_pb2",
+    "@ign-msgs9//:time_py_pb2",
+    "@ign-msgs9//:vector3d_py_pb2",
+    "@ign-msgs9//:wrench_py_pb2",
+    "@ign-msgs9//:publish_py_pb2",
+    "@ign-msgs9//:publishers_py_pb2",
+    "@ign-msgs9//:subscribe_py_pb2",
+    "@ign-msgs9//:topic_info_py_pb2",
+  ],
+)
+
+py_binary(
+  name = "ign_transport_example",
+  srcs = ["ign_transport_example.py"],
+  data = [
+    "//:ignition_transport.so",
+    "@com_google_protobuf//:proto_api",
+  ],
+  deps = [
+    "@ign-msgs9//:header_py_pb2",
+    "@ign-msgs9//:pose_py_pb2",
+    "@ign-msgs9//:quaternion_py_pb2",
+    "@ign-msgs9//:time_py_pb2",
+    "@ign-msgs9//:twist_py_pb2",
+    "@ign-msgs9//:vector3d_py_pb2",
+    "@ign-msgs9//:wrench_py_pb2",
+  ],
+)

--- a/python/ign_msgs_example.py
+++ b/python/ign_msgs_example.py
@@ -1,0 +1,113 @@
+#!/user/bin/env python
+
+# Copyright (C) 2022 Rhys Mainwaring
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ignition.msgs.header_pb2 import Header
+from ignition.msgs.time_pb2 import Time
+from ignition.msgs.vector3d_pb2 import Vector3d
+from ignition.msgs.wrench_pb2 import Wrench
+
+from ignition.msgs.publish_pb2 import Publish
+from ignition.msgs.publishers_pb2 import Publishers
+from ignition.msgs.subscribe_pb2 import Subscribe
+from ignition.msgs.topic_info_pb2 import TopicInfo
+
+import ignition_msgs
+
+from google.protobuf.internal import api_implementation
+
+def main():
+  print("Ignition Messages Example\n")
+
+  #----------------------------------------------
+  # google.protobuf implementation
+  print("proto api type: {}".format(api_implementation.Type()))
+
+  print("----------------------------------------")
+  time_msg = Time()
+  time_msg.sec = 15
+  time_msg.nsec = 21
+  print(type(time_msg))
+  print("isinstance: {}".format(isinstance(time_msg, Time)))
+  ignition_msgs.take_time(time_msg)
+
+  # TODO: failing with use_fast_cpp_proto because isinstance is failing
+  #       for cpp wrapped protobuf.
+  #       See: https://github.com/pybind/pybind11_protobuf/issues/44
+  # print("----------------------------------------")
+  # time_msg = ignition_msgs.make_time()
+  # print(type(time_msg))
+  # print("isinstance: {}".format(isinstance(time_msg, Time)))
+  # ignition_msgs.take_time(time_msg)
+
+  print("----------------------------------------")
+  header_msg = Header()
+  header_msg.stamp.CopyFrom(time_msg)  
+  print(type(header_msg))
+  # print(header_msg)
+
+  print("----------------------------------------")
+  vector3d_msg = Vector3d()
+  vector3d_msg.header.CopyFrom(header_msg)
+  vector3d_msg.x = 21.3
+  vector3d_msg.y = 12.7
+  vector3d_msg.z = 15.2
+  print(type(vector3d_msg))
+  # print(vector3d_msg)
+
+  print("----------------------------------------")
+  wrench_msg = Wrench()
+  wrench_msg.header.CopyFrom(header_msg)
+  wrench_msg.force.CopyFrom(vector3d_msg)
+  wrench_msg.torque.CopyFrom(vector3d_msg)
+  wrench_msg.force_offset.CopyFrom(vector3d_msg)
+  print(type(wrench_msg))
+  # print(wrench_msg)
+  ignition_msgs.take_wrench(wrench_msg)
+
+  print("----------------------------------------")
+  pub_msg = Publish()
+  pub_msg.header.CopyFrom(header_msg)
+  pub_msg.topic = "/force_torque"
+  pub_msg.msg_type = "ignition.msgs.Wrench"
+  pub_msg.host = "127.0.0.1"
+  pub_msg.port = 11311
+  print(type(pub_msg))
+  # print(pub_msg)
+
+  print("----------------------------------------")
+  sub_msg = Subscribe()
+  sub_msg.header.CopyFrom(header_msg)
+  sub_msg.topic = "/force_torque"
+  sub_msg.msg_type = "ignition.msgs.Wrench"
+  sub_msg.host = "127.0.0.1"
+  sub_msg.port = 11311
+  sub_msg.latching = True
+  print(type(sub_msg))
+  # print(sub_msg)
+
+  print("----------------------------------------")
+  topic_msg = TopicInfo()
+  topic_msg.header.CopyFrom(header_msg)
+  topic_msg.msg_type = "ignition.msgs.Wrench"
+  topic_msg.publisher.append(pub_msg)
+  topic_msg.subscriber.append(sub_msg)
+  print(type(topic_msg))
+  # print(topic_msg)
+  ignition_msgs.take_topic_info(topic_msg)
+
+
+if __name__ == "__main__":
+  main()

--- a/python/ign_proto_example.py
+++ b/python/ign_proto_example.py
@@ -1,0 +1,217 @@
+#!/user/bin/env python
+
+# Copyright (C) 2022 Rhys Mainwaring
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ignition.msgs.header_pb2 import Header
+from ignition.msgs.double_pb2 import Double
+from ignition.msgs.double_v_pb2 import Double_V
+from ignition.msgs.float_pb2 import Float
+from ignition.msgs.float_v_pb2 import Float_V
+from ignition.msgs.cmd_vel2d_pb2 import CmdVel2D
+from ignition.msgs.pid_pb2 import PID
+from ignition.msgs.pose_pb2 import Pose
+from ignition.msgs.pose_v_pb2 import Pose_V
+from ignition.msgs.quaternion_pb2 import Quaternion
+from ignition.msgs.time_pb2 import Time
+from ignition.msgs.twist_pb2 import Twist
+from ignition.msgs.vector3d_pb2 import Vector3d
+from ignition.msgs.wrench_pb2 import Wrench
+
+from ignition.msgs.publish_pb2 import Publish
+from ignition.msgs.publishers_pb2 import Publishers
+from ignition.msgs.subscribe_pb2 import Subscribe
+from ignition.msgs.topic_info_pb2 import TopicInfo
+
+from google.protobuf.internal import api_implementation
+
+def main():
+  print("Ignition Protobuf Example\n")
+
+  #----------------------------------------------
+  # google.protobuf implementation
+  print("proto api type: {}".format(api_implementation.Type()))
+
+  print("----------------------------------------")
+  time_msg = Time()
+  time_msg.sec = 15
+  time_msg.nsec = 21
+  print(type(time_msg))
+  print(time_msg)
+
+  print("----------------------------------------")
+  header_msg = Header()
+  header_msg.stamp.CopyFrom(time_msg)  
+  print(type(header_msg))
+  print(header_msg)
+
+  print("----------------------------------------")
+  double_msg = Double()
+  double_msg.header.CopyFrom(header_msg)
+  double_msg.data = 21.3
+  print(type(double_msg))
+  print(double_msg)
+
+  print("----------------------------------------")
+  double_v_msg = Double_V()
+  double_v_msg.data.append(21.4)
+  double_v_msg.data.append(12.8)
+  double_v_msg.data.append(15.6)
+  double_v_msg.data.append(10.1)
+  print(type(double_v_msg))
+  print(double_v_msg)
+
+  print("----------------------------------------")
+  float_msg = Float()
+  float_msg.header.CopyFrom(header_msg)
+  float_msg.data = 21.3
+  print(type(float_msg))
+  print(float_msg)
+
+  print("----------------------------------------")
+  float_v_msg = Float_V()
+  float_v_msg.header.CopyFrom(header_msg)
+  float_v_msg.data.append(21.4)
+  float_v_msg.data.append(12.8)
+  float_v_msg.data.append(15.6)
+  float_v_msg.data.append(10.1)
+  print(type(float_v_msg))
+  print(float_v_msg)
+
+  print("----------------------------------------")
+  vector3d_msg = Vector3d()
+  vector3d_msg.header.CopyFrom(header_msg)
+  vector3d_msg.x = 21.3
+  vector3d_msg.y = 12.7
+  vector3d_msg.z = 15.2
+  print(type(vector3d_msg))
+  print(vector3d_msg)
+
+  print("----------------------------------------")
+  quat_msg = Quaternion()
+  quat_msg.header.CopyFrom(header_msg)
+  quat_msg.x = 0.0
+  quat_msg.y = 0.0
+  quat_msg.z = 0.0
+  quat_msg.w = 1.0
+  print(type(quat_msg))
+  print(quat_msg)
+
+  print("----------------------------------------")
+  pose_msg = Pose()
+  pose_msg.header.CopyFrom(header_msg)
+  pose_msg.name = "base_link"
+  pose_msg.id = 0
+  pose_msg.position.CopyFrom(vector3d_msg)
+  pose_msg.orientation.CopyFrom(quat_msg)
+  print(type(pose_msg))
+  print(pose_msg)
+
+  print("----------------------------------------")
+  pose_v_msg = Pose_V()
+  pose_v_msg.header.CopyFrom(header_msg)
+
+  pose_msg.name = "base_link"
+  pose_msg.id = 0
+  pose_v_msg.pose.append(pose_msg)
+
+  pose_msg.name = "left_motor_link"
+  pose_msg.id = 1
+  pose_v_msg.pose.append(pose_msg)
+
+  pose_msg.name = "right_motor_link"
+  pose_msg.id = 2
+  pose_v_msg.pose.append(pose_msg)
+
+  print(type(pose_v_msg))
+  print(pose_v_msg)
+
+  print("----------------------------------------")
+  cmd_vel_msg = CmdVel2D()
+  cmd_vel_msg.header.CopyFrom(header_msg)
+  cmd_vel_msg.velocity = 8.25
+  cmd_vel_msg.theta = 1.517
+  print(type(cmd_vel_msg))
+  print(cmd_vel_msg)
+
+  print("----------------------------------------")
+  pid_msg = PID()
+  pid_msg.header.CopyFrom(header_msg)
+  double_msg.data = 1.25
+  pid_msg.target_optional.CopyFrom(double_msg)
+  double_msg.data = 0.5
+  pid_msg.p_gain_optional.CopyFrom(double_msg)
+  double_msg.data = 0.05
+  pid_msg.i_gain_optional.CopyFrom(double_msg)
+  double_msg.data = 0.005
+  pid_msg.d_gain_optional.CopyFrom(double_msg)
+  double_msg.data = 1.0
+  pid_msg.i_max_optional.CopyFrom(double_msg)
+  double_msg.data = -1.0
+  pid_msg.i_min_optional.CopyFrom(double_msg)
+  double_msg.data = 10.0
+  pid_msg.limit_optional.CopyFrom(double_msg)
+  print(type(pid_msg))
+  print(pid_msg)
+
+  print("----------------------------------------")
+  twist_msg = Twist()
+  twist_msg.header.CopyFrom(header_msg)
+  twist_msg.linear.CopyFrom(vector3d_msg)
+  twist_msg.angular.CopyFrom(vector3d_msg)
+  print(type(twist_msg))
+  print(twist_msg)
+
+  print("----------------------------------------")
+  wrench_msg = Wrench()
+  wrench_msg.header.CopyFrom(header_msg)
+  wrench_msg.force.CopyFrom(vector3d_msg)
+  wrench_msg.torque.CopyFrom(vector3d_msg)
+  wrench_msg.force_offset.CopyFrom(vector3d_msg)
+  print(type(wrench_msg))
+  print(wrench_msg)
+
+  print("----------------------------------------")
+  pub_msg = Publish()
+  pub_msg.header.CopyFrom(header_msg)
+  pub_msg.topic = "/force_torque"
+  pub_msg.msg_type = "ignition.msgs.Wrench"
+  pub_msg.host = "127.0.0.1"
+  pub_msg.port = 11311
+  print(type(pub_msg))
+  print(pub_msg)
+
+  print("----------------------------------------")
+  sub_msg = Subscribe()
+  sub_msg.header.CopyFrom(header_msg)
+  sub_msg.topic = "/force_torque"
+  sub_msg.msg_type = "ignition.msgs.Wrench"
+  sub_msg.host = "127.0.0.1"
+  sub_msg.port = 11311
+  sub_msg.latching = True
+  print(type(sub_msg))
+  print(sub_msg)
+
+  print("----------------------------------------")
+  topic_msg = TopicInfo()
+  topic_msg.header.CopyFrom(header_msg)
+  topic_msg.msg_type = "ignition.msgs.Wrench"
+  topic_msg.publisher.append(pub_msg)
+  topic_msg.subscriber.append(sub_msg)
+  print(type(topic_msg))
+  print(topic_msg)
+
+
+if __name__ == "__main__":
+  main()

--- a/python/ign_transport_example.py
+++ b/python/ign_transport_example.py
@@ -1,0 +1,149 @@
+#!/user/bin/env python
+
+# Copyright (C) 2022 Rhys Mainwaring
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ignition.msgs.header_pb2 import Header
+from ignition.msgs.time_pb2 import Time
+from ignition.msgs.quaternion_pb2 import Quaternion
+from ignition.msgs.pose_pb2 import Pose
+from ignition.msgs.twist_pb2 import Twist
+from ignition.msgs.vector3d_pb2 import Vector3d
+from ignition.msgs.wrench_pb2 import Wrench
+
+import ignition_transport as ign
+from ignition_transport import AdvertiseMessageOptions
+from ignition_transport import SubscribeOptions
+from ignition_transport import Node
+from ignition_transport import Publisher
+
+from google.protobuf.internal import api_implementation
+
+def main():
+  print("Ignition Transport Example\n")
+
+  #----------------------------------------------
+  # google.protobuf implementation
+  print("proto api type: {}".format(api_implementation.Type()))
+
+  #----------------------------------------------
+  # create transport node
+  node = Node()
+
+  #----------------------------------------------
+  # get a publisher and check valid
+  pub = Publisher()
+  print("valid: {}".format(pub.valid()))
+
+  # create and publish different message types
+  print("----------------------------------------")
+  time_msg = Time()
+  time_msg.sec = 15
+  time_msg.nsec = 21
+  pub.publish(time_msg)
+
+  print("----------------------------------------")
+  header_msg = Header()
+  header_msg.stamp.CopyFrom(time_msg)  
+  pub.publish(header_msg)
+
+  print("----------------------------------------")
+  vector3d_msg = Vector3d()
+  vector3d_msg.header.CopyFrom(header_msg)
+  vector3d_msg.x = 21.3
+  vector3d_msg.y = 12.7
+  vector3d_msg.z = 15.2
+  pub.publish(vector3d_msg)
+
+  print("----------------------------------------")
+  quat_msg = Quaternion()
+  quat_msg.header.CopyFrom(header_msg)
+  quat_msg.x = 0.0
+  quat_msg.y = 0.0
+  quat_msg.z = 0.0
+  quat_msg.w = 1.0
+  pub.publish(quat_msg)
+
+  print("----------------------------------------")
+  pose_msg = Pose()
+  pose_msg.header.CopyFrom(header_msg)
+  pose_msg.name = "base_link"
+  pose_msg.id = 0
+  pose_msg.position.CopyFrom(vector3d_msg)
+  pose_msg.orientation.CopyFrom(quat_msg)
+  pub.publish(pose_msg)
+
+  print("----------------------------------------")
+  twist_msg = Twist()
+  twist_msg.header.CopyFrom(header_msg)
+  twist_msg.linear.CopyFrom(vector3d_msg)
+  twist_msg.angular.CopyFrom(vector3d_msg)
+  pub.publish(twist_msg)
+
+  print("----------------------------------------")
+  wrench_msg = Wrench()
+  wrench_msg.header.CopyFrom(header_msg)
+  wrench_msg.force.CopyFrom(vector3d_msg)
+  wrench_msg.torque.CopyFrom(vector3d_msg)
+  wrench_msg.force_offset.CopyFrom(vector3d_msg)
+  pub.publish(wrench_msg)
+
+  print("----------------------------------------")
+  # AdvertiseMessageOptions defaults
+  pub_options = AdvertiseMessageOptions()
+  print("throttled: {}".format(pub_options.throttled))
+  print("msgs_per_sec: {}".format(pub_options.msgs_per_sec))
+  # apply throttling
+  pub_options.msgs_per_sec = 10
+  print("throttled: {}".format(pub_options.throttled))
+  print("msgs_per_sec: {}".format(pub_options.msgs_per_sec))
+
+  topic = "/motor_1_joint/force_torque"
+  msg_type_name = Wrench.DESCRIPTOR.full_name
+  pub = node.advertise(topic, msg_type_name, pub_options)
+  # pub.publish(wrench_msg)
+
+  print("----------------------------------------")
+  # callbacks
+  def square(x):
+    return x * x
+
+  square_plus_1 = ign.func_ret(square)  
+  plus_1 = ign.func_cpp()  
+
+  print(ign.func_arg(square))
+  print(square_plus_1(4))
+  print(plus_1(number=43))
+
+  def on_msg(msg):
+    print(msg)
+
+  # register callback
+  pubsub = ign.PubSub()
+  pubsub.subscribe(on_msg)
+
+  # publish (should call on_msg)
+  pubsub.publish(wrench_msg)
+
+  print("----------------------------------------")
+  # subscriber
+  def on_force_torque(msg):
+    print(msg)
+
+  sub_options = SubscribeOptions()
+  sub = node.subscribe(topic, on_force_torque, sub_options)
+
+if __name__ == "__main__":
+  main()
+

--- a/src/ignition_msgs.cc
+++ b/src/ignition_msgs.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Rhys Mainwaring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "ignition_msgs.hh"
+
+ignition::msgs::Time MakeTime()
+{
+  ignition::msgs::Time msg;
+  msg.set_sec(10);
+  msg.set_nsec(20);
+  return msg;
+}
+
+void TakeTime(const ignition::msgs::Time& msg)
+{
+  std::cout << msg.DebugString();
+}
+
+void TakeTopicInfo(const ignition::msgs::TopicInfo& msg)
+{
+  std::cout << msg.DebugString();
+}
+
+void TakeWrench(const ignition::msgs::Wrench& msg)
+{
+  std::cout << msg.DebugString();
+}

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Rhys Mainwaring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+#include <string>
+
+#include "ignition/msgs/time.pb.h"
+
+#include "ignition_msgs.hh"
+
+int main(int argc, const char* argv[])
+{
+  // Verify the version of the library we linked against is
+  // compatible with the version used to generate the headers.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  std::cout << "Ignition Msgs Example" << std::endl;
+
+  // example: ignition/msgs/time.proto
+  {
+    ignition::msgs::Time msg;
+    msg.set_sec(11);
+    msg.set_nsec(25);
+    std::cout << msg.DebugString();
+  }
+
+  // example: msgs_tools
+  {
+    auto msg = MakeTime();
+    TakeTime(msg);
+  }
+
+  // Shutdown
+  google::protobuf::ShutdownProtobufLibrary();
+
+  return 0;
+}

--- a/src/pybind11/ignition_msgs.cc
+++ b/src/pybind11/ignition_msgs.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Rhys Mainwaring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <pybind11/pybind11.h>
+
+#include "pybind11_protobuf/native_proto_caster.h"
+
+#include "ignition_msgs.hh"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(ignition_msgs, m) {
+  pybind11_protobuf::ImportNativeProtoCasters();
+
+  m.def("make_time", &MakeTime);
+  m.def("take_time", &TakeTime, pybind11::arg("msg"));
+  m.def("take_topic_info", &TakeTopicInfo, pybind11::arg("msg"));
+  m.def("take_wrench", &TakeWrench, pybind11::arg("msg"));
+}

--- a/src/pybind11/ignition_transport.cc
+++ b/src/pybind11/ignition_transport.cc
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2022 Rhys Mainwaring
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+
+#include "pybind11_protobuf/native_proto_caster.h"
+
+#include <google/protobuf/message.h>
+
+#include <functional>
+
+namespace py = pybind11;
+
+// Needed internally to map the Python subscribe call to Node::SubscribeRaw
+class MessageInfo
+{
+public:
+  virtual ~MessageInfo() {}
+  MessageInfo() {}
+
+  public: const std::string &Topic() const;
+  public: void SetType(const std::string &_type);
+  public: const std::string &Type() const;
+  public: void SetTopic(const std::string &_topic);
+  public: const std::string &Partition() const;
+  public: void SetPartition(const std::string &_partition);
+};
+
+const std::string kGenericMessageType = "google.protobuf.Message";
+
+using RawCallback =
+    std::function<void(const char *_msgData, const size_t _size,
+        const MessageInfo &_info)>;
+
+/// \brief A mock-up of ignition::transport::AdvertiseMessageOptions
+class AdvertiseMessageOptions
+{
+public:
+  virtual ~AdvertiseMessageOptions() {}
+  AdvertiseMessageOptions() {}
+  bool Throttled() const { return this->msgsPerSec != 0; }
+  uint64_t MsgsPerSec() const { return this->msgsPerSec; }
+  void SetMsgsPerSec(const uint64_t _newMsgsPerSec)
+  {
+    this->msgsPerSec = _newMsgsPerSec;
+  }
+
+  private:
+    uint64_t msgsPerSec = 0;
+};
+
+class SubscribeOptions
+{
+public:
+  virtual ~SubscribeOptions() {}
+  SubscribeOptions() {}
+  bool Throttled() const { return this->msgsPerSec != 0; }
+  uint64_t MsgsPerSec() const { return this->msgsPerSec; }
+  void SetMsgsPerSec(const uint64_t _newMsgsPerSec)
+  {
+    this->msgsPerSec = _newMsgsPerSec;
+  }
+
+  private:
+    uint64_t msgsPerSec = 0;
+};
+
+/// \brief A mock-up of ignition::transport::Node
+class Node
+{
+public:
+  virtual ~Node() {}
+  Node() {}
+
+  class Publisher
+  {
+  public:
+    virtual ~Publisher() {}
+    Publisher() {}
+
+    bool Valid() const { return true; }
+
+    bool Publish(const google::protobuf::Message &_msg)
+    {
+      std::cout << _msg.GetTypeName() << "\n";
+      std::cout << _msg.DebugString();
+      return true;
+    }
+
+    bool ThrottledUpdateReady() const { return true; }
+
+    bool UpdateThrottling() { return true; }
+
+    bool HasConnections() const { return true; }
+  };
+
+  /// \brief A mock-up of the advertise function
+  ///
+  /// \param _msgTypeName is the protobuf type obtained using
+  /// GetTypeName in C++ or DESCRIPTOR.full_name in Python
+  Node::Publisher Advertise(
+      const std::string &_topic,
+      const std::string &_msgTypeName,
+      const AdvertiseMessageOptions &_options = AdvertiseMessageOptions())
+  {
+    std::cout << "Advertising" << "\n"
+        << "topic: " << _topic << "\n"   
+        << "type: " << _msgTypeName << "\n";
+    
+    return Publisher();
+  }
+
+  std::vector<std::string> AdvertisedTopics() const
+  {
+    std::vector<std::string> topics;
+    topics.push_back("/topic1");
+    topics.push_back("/topic2");
+    topics.push_back("/topic3");
+    topics.push_back("/topic4");
+    return topics;
+  }
+
+  bool Subscribe(
+      const std::string &_topic,
+      std::function<void(const google::protobuf::Message &_msg)> &_callback,
+      const SubscribeOptions &_opts = SubscribeOptions())
+  {
+    // std::string msgType = kGenericMessageType;
+    
+    // RawCallback cb = [&](
+    //   const char *_msgData,
+    //   const size_t _size,
+    //   const MessageInfo &_info) -> void
+    // {
+    //   // determine the correct message type
+    //   msgType = _info.Type();
+
+    //   // create the message from the string and metadata
+    //   google::protobuf::Message msg;
+
+    //   // call out callback
+    //   _callback(msg);
+    // };
+
+    // return SubscribeRaw(_topic, cb, msgType, _opts);
+
+    // Alternative
+    // return Subscribe<google::protobuf::Message>(_topic, _callback, _opts);
+    return true;
+  }
+
+  bool SubscribeRaw(
+    const std::string &_topic,
+    const RawCallback &_callback,
+    const std::string &_msgType = kGenericMessageType,
+    const SubscribeOptions &_opts = SubscribeOptions())
+  {
+    // forward to ignition::transport::Node::SubscribeRaw
+  }
+
+  std::vector<std::string> SubscribedTopics() const
+  {
+    std::vector<std::string> topics;
+    topics.push_back("/topic1");
+    topics.push_back("/topic2");
+    topics.push_back("/topic3");
+    topics.push_back("/topic4");
+    return topics;
+  }
+
+};
+
+// callback function examples
+//
+// https://pybind11.readthedocs.io/en/stable/advanced/cast/functional.html
+//
+int func_arg(const std::function<int(int)> &f) {
+  return f(10);
+}
+
+std::function<int(int)> func_ret(const std::function<int(int)> &f) {
+  return [f](int i) {
+    return f(i) + 1;
+  };
+}
+
+py::cpp_function func_cpp() {
+  return py::cpp_function([](int i) { return i+1; },
+      py::arg("number"));
+}
+
+class PubSub
+{
+public:
+  virtual ~PubSub() {}
+  PubSub() {}
+
+  void Publish(const google::protobuf::Message &_msg)
+  {
+    if (this->callback)
+    {
+      this->callback(_msg);
+    }
+  }
+
+  void Subscribe(std::function<void(const google::protobuf::Message &_msg)> &_callback)
+  {
+    this->callback = _callback;
+  }
+
+  std::function<void(const google::protobuf::Message &_msg)> callback;
+};
+
+/// \brief Define pybind11 bindings for ignition::transport objects
+void define_transport_node(py::object module)
+{
+  py::class_<AdvertiseMessageOptions>(module, "AdvertiseMessageOptions")
+      .def(py::init<>())
+      .def_property_readonly("throttled",
+          &AdvertiseMessageOptions::Throttled)
+      .def_property("msgs_per_sec",
+          &AdvertiseMessageOptions::MsgsPerSec,
+          &AdvertiseMessageOptions::SetMsgsPerSec)
+      ;
+
+  py::class_<SubscribeOptions>(module, "SubscribeOptions")
+      .def(py::init<>())
+      .def_property_readonly("throttled",
+          &SubscribeOptions::Throttled)
+      .def_property("msgs_per_sec",
+          &SubscribeOptions::MsgsPerSec,
+          &SubscribeOptions::SetMsgsPerSec)
+      ;
+
+  py::class_<Node>(module, "Node")
+      .def(py::init<>())
+      .def("advertise", &Node::Advertise,
+          pybind11::arg("topic"),
+          pybind11::arg("msg_type_name"),
+          pybind11::arg("options"))
+      .def("advertised_topics", &Node::AdvertisedTopics)
+      .def("subscribe", &Node::Subscribe,
+          pybind11::arg("topic"),
+          pybind11::arg("callback"),
+          pybind11::arg("options"))
+      .def("subscribed_topics", &Node::SubscribedTopics)
+      ;
+
+  py::class_<Node::Publisher>(module, "Publisher")
+      .def(py::init<>())
+      .def("valid", &Node::Publisher::Valid)
+      .def("publish", &Node::Publisher::Publish,
+          pybind11::arg("msg"))
+      .def("throttled_update_ready",
+          &Node::Publisher::ThrottledUpdateReady)
+      .def("update_throttling",
+          &Node::Publisher::UpdateThrottling)
+      .def("has_connections",
+          &Node::Publisher::HasConnections);
+      ;
+
+  py::class_<PubSub>(module, "PubSub")
+      .def(py::init<>())
+      .def("publish", &PubSub::Publish,
+          pybind11::arg("msg"))
+      .def("subscribe", &PubSub::Subscribe,
+          pybind11::arg("callback"))
+      ;
+
+}
+
+/// \brief Define the ignition_transport module
+PYBIND11_MODULE(ignition_transport, m) {
+  pybind11_protobuf::ImportNativeProtoCasters();
+
+  define_transport_node(m);
+
+  m.def("func_arg", &func_arg);
+  m.def("func_ret", &func_ret);
+  m.def("func_cpp", &func_cpp);
+}


### PR DESCRIPTION
Add simple protobuf example and generate bindings
- Generate bindings for Python and C++
- For C++ compile the bindings into a library
- Provide example programs for C++ and Python

Add example using pybind11_protobuf
- Add external dependency on pybind11_protobuf
- Add simple C++ example with functions accepting protobuf messages
- Add pybind11 bindings
- Update python test example

Update pybind11_protobuf example
- Move functions using the time.proto to separate library
- Add example to main.cc
- Update the pybind11_protobuf submodule version

Disable the ignition_msgs test
- This test broken as ignition_msgs is missing a dependency from pybind11_protobuf

Rename the extension module to py_time_utils

Add test example from pybind11_protobuf

Update submodule for pybind11_protobuf

Remove unused protos

Add Bazel build files
- Add support for building with Bazel
- Update the python examples
- Add external protobuf patch required in pybind11_protobuf

Refactor time.proto -> time2.proto
- Rename example time.proto in preparation for building ignition_msgs
- Add dependency to ignition repos in workspace

Build protobuf bindings for a sample of ignition.msgs
- Add external build file for ignition-msgs
- Add python example binary to verify python protobuf bindings

Add ignition.msgs.pose

Add license

Add further ignition-msgs types
- Add cmd_vel2d, double, double_vm float, float_v
- Fix deps for pose_proto

Add message types
- Add message types for pid, twist, wrench, publish, publisher, subscribe. topic_info
- Add basic checks in python module

Add test module for ignition messages

Update README and add further module examples
- Add pybind11 examples for wrench and topic_info

Clean up project
- Leave only the ignition-msgs bindings and examples

Add .gitignore

Partial fix to cmake build

Clean up
- Remove unused header file
- Add license to cpp files
- Correct workspace name

Add placeholder for ignition-transport bindings

Add mock-up for ignition-transport Node

Refactor - rename msg module to align with transport
- Rename example module for ignition messages
- Rename python example scripts

Add mock-up for advertising topics

Initial draft of subscribe mock-up (callbacks)

Further additions to the subscribe mock-up

Rename ignition-msgs9 ->  ign-msgs9

Enable use_fast_cpp_proto for Python bindings
- Add flag to .bazelrc (set to false though as there is still an unresolved issue with isinstance for the C++ implementation)
- Update C++ targets to use includes instead of copts
- Update ign-msgs9.BUILD to use Python protobuf rules from https://rules-proto-grpc.com
- Update version of pybind11_protobuf
- Update ign_msgs_example to highlight issue

Update README and examples
- Update README with install instructions and more detail about the examples
- Disable the failing case in ign_msgs_example.py
- Output the msg debug string to std::cout

Signed-off-by: Rhys Mainwaring <rhys.mainwaring@me.com>