### PR TITLE
Remove python_ignition prefix from the ign_transport module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ make
 
 ## Usage
 
+### Ignition msg bindings 
+
 The Bazel build file `ign-msgs9.BUILD` defines targets for a selection of messages.
 For example the targets for `proto/ignition/msgs/time.proto` are:
 
@@ -189,10 +191,20 @@ py_binary(
 )
 ```
 
+### Ignition transport bindings 
+
+The Python for `ign-transport` are contained in a module called `ign_transport`.
+
+Because of the way Bazel names and locates packages for subdirectories, the module
+is located at `~/ignition/bazel-bin/python_ignition/ign_transport.so`, however Bazel sets the Python path to `~/ignition/bazel-bin`. To avoid prefixing all the module imports with `python_ignition` add the module location the Python path with:
+
+```bash
+export PYTHONPATH=~/ignition/bazel-bin/python_ignition:$PYTHONPATH
+```
+
 ## Examples
 
 A number of examples in C++ and Python are provided.
-
 
 ---
 

--- a/python/ign_topic_echo.py
+++ b/python/ign_topic_echo.py
@@ -23,8 +23,8 @@ $ ign topic -i -e /topic
 import argparse
 import time
 
-from python_ignition.ignition_transport import SubscribeOptions
-from python_ignition.ignition_transport import Node
+from ignition_transport import SubscribeOptions
+from ignition_transport import Node
 
 # callback - prints the raw message
 def cb(msg):

--- a/python/ign_topic_info.py
+++ b/python/ign_topic_info.py
@@ -22,7 +22,7 @@ $ ign topic -i -t /topic
 
 import argparse
 
-from python_ignition.ignition_transport import Node
+from ignition_transport import Node
 
 def main():
     # process command line

--- a/python/ign_topic_list.py
+++ b/python/ign_topic_list.py
@@ -20,7 +20,7 @@ Replicate the ign_tools command:
 $ ign topic -l
 '''
 
-from python_ignition.ignition_transport import Node
+from ignition_transport import Node
 
 def main():
     # create a transport node

--- a/python/pub_all_msg_types.py
+++ b/python/pub_all_msg_types.py
@@ -35,9 +35,9 @@ from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 from ignition.msgs.wrench_pb2 import Wrench
 
-from python_ignition.ignition_transport import AdvertiseMessageOptions
-from python_ignition.ignition_transport import Node
-from python_ignition.ignition_transport import Publisher
+from ignition_transport import AdvertiseMessageOptions
+from ignition_transport import Node
+from ignition_transport import Publisher
 
 def main():
     # Create a transport node and advertise options

--- a/python/publisher.py
+++ b/python/publisher.py
@@ -18,9 +18,9 @@ import time
 
 from ignition.msgs.stringmsg_pb2 import StringMsg
 
-from python_ignition.ignition_transport import AdvertiseMessageOptions
-from python_ignition.ignition_transport import Node
-from python_ignition.ignition_transport import Publisher
+from ignition_transport import AdvertiseMessageOptions
+from ignition_transport import Node
+from ignition_transport import Publisher
 
 def main():
     # Create a transport node and advertise a topic

--- a/python/rover_publisher.py
+++ b/python/rover_publisher.py
@@ -25,9 +25,9 @@ from ignition.msgs.time_pb2 import Time
 from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 
-from python_ignition.ignition_transport import AdvertiseMessageOptions
-from python_ignition.ignition_transport import Node
-from python_ignition.ignition_transport import Publisher
+from ignition_transport import AdvertiseMessageOptions
+from ignition_transport import Node
+from ignition_transport import Publisher
 
 def main():
     # Create a transport node and advertise a topic

--- a/python/rover_subscriber.py
+++ b/python/rover_subscriber.py
@@ -22,8 +22,8 @@ from ignition.msgs.quaternion_pb2 import Quaternion
 from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 
-from python_ignition.ignition_transport import Node
-from python_ignition.ignition_transport import SubscribeOptions
+from ignition_transport import Node
+from ignition_transport import SubscribeOptions
 
 
 def pose_cb(msg: Pose) -> None:

--- a/python/subscriber.py
+++ b/python/subscriber.py
@@ -19,8 +19,8 @@ import typing
 
 from ignition.msgs.stringmsg_pb2 import StringMsg
 
-from python_ignition.ignition_transport import SubscribeOptions
-from python_ignition.ignition_transport import Node
+from ignition_transport import SubscribeOptions
+from ignition_transport import Node
 
 def cb(msg: StringMsg) -> None:
     print("Msg: [{}] from Python".format(msg.data))

--- a/python/transport_example.py
+++ b/python/transport_example.py
@@ -22,11 +22,10 @@ from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 from ignition.msgs.wrench_pb2 import Wrench
 
-import python_ignition.ignition_transport as ign
-from python_ignition.ignition_transport import AdvertiseMessageOptions
-from python_ignition.ignition_transport import SubscribeOptions
-from python_ignition.ignition_transport import Node
-from python_ignition.ignition_transport import Publisher
+from ignition_transport import AdvertiseMessageOptions
+from ignition_transport import SubscribeOptions
+from ignition_transport import Node
+from ignition_transport import Publisher
 
 from google.protobuf.internal import api_implementation
 
@@ -114,17 +113,6 @@ def main():
     msg_type_name = Wrench.DESCRIPTOR.full_name
     pub = node.advertise(topic, msg_type_name, pub_options)
     pub.publish(wrench_msg)
-
-    # print("----------------------------------------")
-    def on_msg(msg):
-        print(msg)
-
-    # register callback
-    # pubsub = ign.PubSub()
-    # pubsub.subscribe(on_msg)
-
-    # publish (should call on_msg)
-    # pubsub.publish(wrench_msg)
 
     print("----------------------------------------")
     def on_force_torque(msg):


### PR DESCRIPTION
This PR changes the import statement for the module `ign_transport` in the Python examples

For CMake builds the module is not prefixed by the project name, and the requirement to include the `python_ignition` prefix is an artefact of the Bazel build.

The README contains instructions for setting the PYTHONPATH to allow the use of either build method. 