### PR TITLE
Add CMake build for macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/pybind11_protobuf"]
 	path = external/pybind11_protobuf
-	url = https://github.com/pybind/pybind11_protobuf.git
+	url = https://github.com/srmainwaring/pybind11_protobuf.git
 [submodule "external/protobuf"]
 	path = external/protobuf
 	url = https://github.com/protocolbuffers/protobuf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # macOS: $ brew install protobuf
 # 
 find_package(Protobuf REQUIRED)
+# message("Protobuf_FOUND: ${Protobuf_FOUND}")
+# message("Protobuf_VERSION: ${Protobuf_VERSION}")
+# message("Protobuf_LIBRARY: ${Protobuf_LIBRARY}")
+# message("Protobuf_INCLUDE_DIR: ${Protobuf_INCLUDE_DIR}")
 
 #============================================================================
 # Find google abseil
@@ -38,68 +42,101 @@ set(IGN_TRANSPORT_VER 12)
 find_package(ignition-transport${IGN_TRANSPORT_VER} REQUIRED)
 
 #============================================================================
-# subdirectories for external dependencies and protobuf definitions
+# subdirectories for external dependencies
 
 # add_subdirectory(external)
-# add_subdirectory(proto)
 
 #============================================================================
-# msgs_tools
+# ignition_msgs_lib C++ library
 
-# add_library(msgs_tools src/msgs_tools.cc)
+add_library(ignition_msgs_lib src/ignition_msgs.cc)
 
-# target_link_libraries(msgs_tools ign_proto ${PROTOBUF_LIBRARY})
+target_link_libraries(ignition_msgs_lib
+  ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+)
 
-# target_include_directories(msgs_tools
-#   PRIVATE
-#     ${CMAKE_CURRENT_BINARY_DIR}
-#     ${PROJECT_SOURCE_DIR}/include
-#     ${Protobuf_INCLUDE_DIR}
-# )
+target_include_directories(ignition_msgs_lib
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
 
 #============================================================================
 # ignition_msgs Python extension module
 
-# pybind11_add_module(msgs_tools_module MODULE
-#   src/pybind11/msgs_tools_module.cc
-# )
+pybind11_add_module(ignition_msgs MODULE
+  src/pybind11/ignition_msgs.cc
+)
 
-# target_include_directories(msgs_tools_module
-#   PRIVATE
-#     ${CMAKE_CURRENT_BINARY_DIR}
-#     ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
-#     ${PROJECT_SOURCE_DIR}/include
-#     ${PROTOBUF_INCLUDE_DIR}
-# )
-  
-# target_link_libraries(msgs_tools_module
-#   PRIVATE
-#     pybind11_native_proto_caster
-#     pybind11_proto
-#     pybind11_proto_utils
-#     pybind11_proto_cast_util
-#     ign_proto
-#     msgs_tools
-# )
+target_link_libraries(ignition_msgs
+  PRIVATE
+    ignition_msgs_lib
+    # pybind11_native_proto_caster
+    # pybind11_proto
+    # pybind11_proto_utils
+    # pybind11_proto_cast_util
+)
 
-# add_dependencies(msgs_tools_module msgs_tools)
+target_include_directories(ignition_msgs
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    # ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+)
+
+add_dependencies(ignition_msgs
+  ignition_msgs_lib
+)
+
+#============================================================================
+# ignition_transport Python extension module
+
+pybind11_add_module(ignition_transport MODULE
+  src/pybind11/ignition_transport.cc
+)
+
+target_link_libraries(ignition_transport
+  PRIVATE
+    ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+    ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
+    ${Protobuf_LIBRARY}
+    # pybind11_native_proto_caster
+    # pybind11_proto
+    # pybind11_proto_utils
+    # pybind11_proto_cast_util
+)
+
+target_include_directories(ignition_msgs
+  PRIVATE
+    ${Protobuf_INCLUDE_DIR}
+    # ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+)
 
 #============================================================================
 # main
 
-# add_executable(main src/main.cc)
+add_executable(main src/main.cc)
 
-# target_link_libraries(main
-#   ign_proto msgs_tools
-#   ${PROTOBUF_LIBRARY}
-# )
+target_link_libraries(main
+  ignition_msgs_lib
+  ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+)
 
-# target_include_directories(main
-#   PRIVATE
-#     ${CMAKE_CURRENT_BINARY_DIR}
-#     ${PROJECT_SOURCE_DIR}/include
-#     ${Protobuf_INCLUDE_DIR}
-# )
+target_include_directories(main
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+add_dependencies(main
+  ignition_msgs_lib
+)
+
+#============================================================================
+# msg_example
+
+add_executable(msg_example src/msg_example.cc)
+
+target_link_libraries(msg_example
+  ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
+)
 
 #============================================================================
 # publisher

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,9 @@ find_package(ignition-transport${IGN_TRANSPORT_VER} REQUIRED)
 #============================================================================
 # ignition_msgs_lib C++ library
 
-add_library(ignition_msgs_lib src/ignition_msgs.cc)
+add_library(ignition_msgs_lib SHARED
+  src/ignition_msgs.cc
+)
 
 target_link_libraries(ignition_msgs_lib
   ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Protobuf REQUIRED)
 # 
 # macOS: $ brew install abseil
 # 
-find_package(absl REQUIRED)
+# find_package(absl REQUIRED)
 
 #============================================================================
 # Find pybind11
@@ -30,7 +30,7 @@ find_package(absl REQUIRED)
 # macOS: $ brew install pybind11
 # 
 find_package(Python COMPONENTS Interpreter Development)
-find_package(pybind11 CONFIG)
+# find_package(pybind11 CONFIG)
 
 #============================================================================
 # Find the ign-msgs library
@@ -44,7 +44,7 @@ find_package(ignition-transport${IGN_TRANSPORT_VER} REQUIRED)
 #============================================================================
 # subdirectories for external dependencies
 
-# add_subdirectory(external)
+add_subdirectory(external)
 
 #============================================================================
 # ignition_msgs_lib C++ library
@@ -72,16 +72,14 @@ pybind11_add_module(ignition_msgs MODULE
 target_link_libraries(ignition_msgs
   PRIVATE
     ignition_msgs_lib
-    # pybind11_native_proto_caster
-    # pybind11_proto
-    # pybind11_proto_utils
-    # pybind11_proto_cast_util
+    ${Protobuf_LIBRARY}
+    pybind11_native_proto_caster
 )
 
 target_include_directories(ignition_msgs
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include
-    # ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+    ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
 )
 
 add_dependencies(ignition_msgs
@@ -100,16 +98,13 @@ target_link_libraries(ignition_transport
     ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
     ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
     ${Protobuf_LIBRARY}
-    # pybind11_native_proto_caster
-    # pybind11_proto
-    # pybind11_proto_utils
-    # pybind11_proto_cast_util
+    pybind11_native_proto_caster
 )
 
-target_include_directories(ignition_msgs
+target_include_directories(ignition_transport
   PRIVATE
     ${Protobuf_INCLUDE_DIR}
-    # ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+    ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
 )
 
 #============================================================================

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,1 +1,1 @@
-# add_subdirectory(pybind11_protobuf)
+add_subdirectory(pybind11_protobuf)

--- a/python/ign_topic_echo.py
+++ b/python/ign_topic_echo.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/ign_topic_info.py
+++ b/python/ign_topic_info.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/ign_topic_list.py
+++ b/python/ign_topic_list.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/msgs_example.py
+++ b/python/msgs_example.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/pub_all_msg_types.py
+++ b/python/pub_all_msg_types.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/publisher.py
+++ b/python/publisher.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/rover_publisher.py
+++ b/python/rover_publisher.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/rover_subscriber.py
+++ b/python/rover_subscriber.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/subscriber.py
+++ b/python/subscriber.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/python/transport_example.py
+++ b/python/transport_example.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2022 Rhys Mainwaring
 #

--- a/src/pybind11/ignition_msgs.cc
+++ b/src/pybind11/ignition_msgs.cc
@@ -17,14 +17,14 @@
 
 #include <pybind11/pybind11.h>
 
-#include "pybind11_protobuf/native_proto_caster.h"
+// #include "pybind11_protobuf/native_proto_caster.h"
 
 #include "ignition_msgs.hh"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(ignition_msgs, m) {
-  pybind11_protobuf::ImportNativeProtoCasters();
+  // pybind11_protobuf::ImportNativeProtoCasters();
 
   m.def("make_time", &MakeTime);
   m.def("take_time", &TakeTime, pybind11::arg("msg"));

--- a/src/pybind11/ignition_msgs.cc
+++ b/src/pybind11/ignition_msgs.cc
@@ -17,14 +17,14 @@
 
 #include <pybind11/pybind11.h>
 
-// #include "pybind11_protobuf/native_proto_caster.h"
+#include "pybind11_protobuf/native_proto_caster.h"
 
 #include "ignition_msgs.hh"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(ignition_msgs, m) {
-  // pybind11_protobuf::ImportNativeProtoCasters();
+  pybind11_protobuf::ImportNativeProtoCasters();
 
   m.def("make_time", &MakeTime);
   m.def("take_time", &TakeTime, pybind11::arg("msg"));

--- a/src/pybind11/ignition_transport.cc
+++ b/src/pybind11/ignition_transport.cc
@@ -22,7 +22,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
-#include "pybind11_protobuf/native_proto_caster.h"
+// #include "pybind11_protobuf/native_proto_caster.h"
 
 #include <google/protobuf/message.h>
 
@@ -33,7 +33,7 @@ namespace py = pybind11;
 /// \brief Define pybind11 bindings for ignition::transport objects
 void define_transport_node(py::object module)
 {
-  pybind11_protobuf::ImportNativeProtoCasters();
+  // pybind11_protobuf::ImportNativeProtoCasters();
 
   using namespace ignition;
   using namespace transport;
@@ -170,7 +170,7 @@ void define_transport_node(py::object module)
 
 /// \brief Define the ignition_transport module
 PYBIND11_MODULE(ignition_transport, m) {
-  pybind11_protobuf::ImportNativeProtoCasters();
+  // pybind11_protobuf::ImportNativeProtoCasters();
 
   define_transport_node(m);
 

--- a/src/pybind11/ignition_transport.cc
+++ b/src/pybind11/ignition_transport.cc
@@ -22,7 +22,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
-// #include "pybind11_protobuf/native_proto_caster.h"
+#include "pybind11_protobuf/native_proto_caster.h"
 
 #include <google/protobuf/message.h>
 
@@ -33,7 +33,7 @@ namespace py = pybind11;
 /// \brief Define pybind11 bindings for ignition::transport objects
 void define_transport_node(py::object module)
 {
-  // pybind11_protobuf::ImportNativeProtoCasters();
+  pybind11_protobuf::ImportNativeProtoCasters();
 
   using namespace ignition;
   using namespace transport;
@@ -170,7 +170,7 @@ void define_transport_node(py::object module)
 
 /// \brief Define the ignition_transport module
 PYBIND11_MODULE(ignition_transport, m) {
-  // pybind11_protobuf::ImportNativeProtoCasters();
+  pybind11_protobuf::ImportNativeProtoCasters();
 
   define_transport_node(m);
 


### PR DESCRIPTION
This PR provides an initial CMake build for macOS

## Upstream dependencies

- There is an upstream dependency on CMake support for [`pybind11_protobuf`](https://github.com/pybind/pybind11_protobuf). The submodule references a fork https://github.com/srmainwaring/pybind11_protobuf/tree/feature/cmake that has a CMake build.

## Details

- `CMakeLists.txt` is updated to include the same targets as the Bazel build.
- The Python shebangs are corrected and files are made executable

