### PR TITLE
Update README and examples for CMake build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "external/pybind11_protobuf"]
 	path = external/pybind11_protobuf
 	url = https://github.com/srmainwaring/pybind11_protobuf.git
-[submodule "external/protobuf"]
-	path = external/protobuf
-	url = https://github.com/protocolbuffers/protobuf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,17 +11,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # macOS: $ brew install protobuf
 # 
 find_package(Protobuf REQUIRED)
-# message("Protobuf_FOUND: ${Protobuf_FOUND}")
-# message("Protobuf_VERSION: ${Protobuf_VERSION}")
-# message("Protobuf_LIBRARY: ${Protobuf_LIBRARY}")
-# message("Protobuf_INCLUDE_DIR: ${Protobuf_INCLUDE_DIR}")
-
-#============================================================================
-# Find google abseil
-# 
-# macOS: $ brew install abseil
-# 
-# find_package(absl REQUIRED)
 
 #============================================================================
 # Find pybind11

--- a/python/rover_publisher.py
+++ b/python/rover_publisher.py
@@ -40,7 +40,7 @@ def main():
     pose_pub = node.advertise(
         pose_topic, pose_msg_type_name, pub_options)
     if pose_pub.valid():
-        print("Advertising {} on topic[{}]".format(
+        print("Advertising {} on topic [{}]".format(
             pose_msg_type_name, pose_topic))
     else:
         print("Error advertising topic [{}]".format(pose_topic))
@@ -50,7 +50,7 @@ def main():
     twist_pub = node.advertise(
         twist_topic, twist_msg_type_name, pub_options)
     if twist_pub.valid():
-        print("Advertising {} on topic[{}]".format(
+        print("Advertising {} on topic [{}]".format(
             twist_msg_type_name, twist_topic))
     else:
         print("Error advertising topic [{}]".format(twist_topic))

--- a/python/rover_subscriber.py
+++ b/python/rover_subscriber.py
@@ -27,12 +27,10 @@ from ignition_transport import SubscribeOptions
 
 
 def pose_cb(msg: Pose) -> None:
-    print("Got pose")
-    # print("{}".format(msg))
+    print("{}".format(msg))
 
 def twist_cb(msg: Twist) -> None:
-    print("Got twist")
-    # print("{}".format(msg))
+    print("{}".format(msg))
 
 def main():
     # create a transport node

--- a/src/msg_example.cc
+++ b/src/msg_example.cc
@@ -23,8 +23,6 @@ using namespace ignition;
 
 int main(int argc, const char *argv[])
 {
-  std::cout << "@python_ignition//:msg_example" << std::endl;
-
   // https://ignitionrobotics.org/api/msgs/8.1/cppgetstarted.html
   {
     ignition::msgs::Vector3d point1;


### PR DESCRIPTION
This PR updates the documentation and examples to focus on the CMake build

- Update the README to prioritise the building and using the examples with a CMake build
- Remove protobuf from submodules
- Remove unused comments and dependencies from CMakeLists.txt
- Minor updates to some examples
