### PR TITLE
Align project structure with conventions for Python extensions used in ign-gazebo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,27 @@
-#———————————————————————————————————————————————————————————————————————
-# python_ignition using Bazel builds
+package(default_visibility = ["//visibility:public"])
 
-load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+#———————————————————————————————————————————————————————————————————————
+# ignition_py
+# 
+# This is a Python library meta-target to hoist the pybind11 modules
+# under src/pybind11 to the root directory so that
+# 
+#   imports = ["src/pybind11"]
+# 
+# can be used. It ensures that the 'ignition' package is visible on
+# the PYTHONPATH and can be imported into modules without being prefixed
+# by the fullpackage path 'python_ignition.src.pybind11'
+# 
+py_library(
+  name = "ignition_py",
+  imports = [
+    "src/pybind11",
+  ],
+  data = [
+    "//python_ignition/src/pybind11/ignition/msgs:extras.so",
+    "//python_ignition/src/pybind11/ignition:transport.so",
+  ],
+)
 
 #———————————————————————————————————————————————————————————————————————
 # deps_check
@@ -27,7 +47,6 @@ cc_binary(
     # "@gl",
     # "@X//:Xaw",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -42,7 +61,6 @@ cc_binary(
     "//ign_msgs:ign_msgs",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -58,7 +76,6 @@ cc_binary(
     "//ign_transport:ign_transport",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -74,7 +91,6 @@ cc_binary(
     "//ign_transport:ign_transport",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -91,7 +107,6 @@ cc_binary(
     "//ign_transport:ign_transport",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -108,23 +123,8 @@ cc_binary(
     "//ign_transport:ign_transport",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
 
-#———————————————————————————————————————————————————————————————————————
-# C++ library to expose via pybind11
-cc_library(
-  name = "ignition_msgs_lib",
-  srcs = ["src/ignition_msgs.cc"],
-  hdrs = ["include/ignition_msgs.hh"],
-  includes = ["include"],
-  deps = [
-    "@ign-msgs9//:time_cc_proto",
-    "@ign-msgs9//:topic_info_cc_proto",
-    "@ign-msgs9//:wrench_cc_proto",
-  ],
-  visibility = ["//visibility:public"],
-)
 
 #———————————————————————————————————————————————————————————————————————
 # C++ example
@@ -133,9 +133,8 @@ cc_binary(
   srcs = ["src/main.cc"],
   includes = ["include"],
   deps = [
-    ":ignition_msgs_lib",
+    "//python_ignition/src/pybind11/ignition/msgs:ignition_msgs_extras_lib",
   ],
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -149,36 +148,4 @@ cc_binary(
     "//ign_transport:ign_transport",
     "@com_google_protobuf//:protobuf",
   ],
-  visibility = ["//visibility:public"],
 )
-
-#———————————————————————————————————————————————————————————————————————
-# Python extension module example
-pybind_extension(
-  name = "ignition_msgs",
-  srcs = ["src/pybind11/ignition_msgs.cc"],
-  includes = ["include"],
-  deps = [
-    ":ignition_msgs_lib",
-    "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
-    "@com_google_protobuf//:protobuf",
-  ],
-  visibility = ["//visibility:public"],
-)
-
-#———————————————————————————————————————————————————————————————————————
-# ignition_transport
-# 
-# Python bindings for ignition transport
-
-pybind_extension(
-  name = "ignition_transport",
-  srcs = ["src/pybind11/ignition_transport.cc"],
-  deps = [
-    "//ign_transport:ign_transport",
-    "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
-    "@com_google_protobuf//:protobuf",
-  ],
-  visibility = ["//visibility:public"],
-)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,53 +36,61 @@ find_package(ignition-transport${IGN_TRANSPORT_VER} REQUIRED)
 add_subdirectory(external)
 
 #============================================================================
-# ignition_msgs_lib C++ library
+# ignition_msgs_extras_lib C++ library
 
-add_library(ignition_msgs_lib SHARED
-  src/ignition_msgs.cc
+add_library(ignition_msgs_extras_lib SHARED
+  src/pybind11/ignition/msgs/extras.cc
 )
 
-target_link_libraries(ignition_msgs_lib
+target_link_libraries(ignition_msgs_extras_lib
   ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
 )
 
-target_include_directories(ignition_msgs_lib
+target_include_directories(ignition_msgs_extras_lib
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include
 )
 
 #============================================================================
-# ignition_msgs Python extension module
+# msgs extras Python extension module
 
-pybind11_add_module(ignition_msgs MODULE
-  src/pybind11/ignition_msgs.cc
+pybind11_add_module(extras MODULE
+  src/pybind11/ignition/msgs/_ignition_msgs_extras_pybind11.cc
 )
 
-target_link_libraries(ignition_msgs
+target_link_libraries(extras
   PRIVATE
-    ignition_msgs_lib
+    ignition_msgs_extras_lib
+    ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
     ${Protobuf_LIBRARY}
     pybind11_native_proto_caster
 )
 
-target_include_directories(ignition_msgs
+target_include_directories(extras
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
 )
 
-add_dependencies(ignition_msgs
-  ignition_msgs_lib
+add_dependencies(extras
+  ignition_msgs_extras_lib
+)
+
+set_target_properties(extras
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition/msgs"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition/msgs"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition/msgs"
 )
 
 #============================================================================
-# ignition_transport Python extension module
+# transport Python extension module
 
-pybind11_add_module(ignition_transport MODULE
-  src/pybind11/ignition_transport.cc
+pybind11_add_module(transport MODULE
+  src/pybind11/ignition/transport/_ignition_transport_pybind11.cc
 )
 
-target_link_libraries(ignition_transport
+target_link_libraries(transport
   PRIVATE
     ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
     ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
@@ -90,10 +98,17 @@ target_link_libraries(ignition_transport
     pybind11_native_proto_caster
 )
 
-target_include_directories(ignition_transport
+target_include_directories(transport
   PRIVATE
     ${Protobuf_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/external/pybind11_protobuf
+)
+
+set_target_properties(transport
+  PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python/ignition"
 )
 
 #============================================================================
@@ -102,7 +117,7 @@ target_include_directories(ignition_transport
 add_executable(main src/main.cc)
 
 target_link_libraries(main
-  ignition_msgs_lib
+  ignition_msgs_extras_lib
   ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
 )
 
@@ -112,7 +127,7 @@ target_include_directories(main
 )
 
 add_dependencies(main
-  ignition_msgs_lib
+  ignition_msgs_extras_lib
 )
 
 #============================================================================

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ generated Python protobuf bindings.
 
 ```bash
 cd ~/workspace/src/python-ignition
-export PYTHONPATH=${PYTHONPATH}:$(pwd)/build::$(pwd)/build/python
+export PYTHONPATH=${PYTHONPATH}:$(pwd)/build/python
 ```
 
 ## Usage
@@ -64,7 +64,7 @@ print(msg)
 
 ### `ign-transport` bindings 
 
-The Python bindings for `ign-transport` are contained in a module called `ign_transport`.
+The Python bindings for `ign-transport` are contained in a module called `transport`.
 The object naming and usage for the most part follows the C++ interface,
 so the C++ Ignition Tutorials are a good guide on how to use the library.
 
@@ -73,9 +73,8 @@ Publish:
 ```python
 from ignition.msgs.stringmsg_pb2 import StringMsg
 
-from ignition_transport import AdvertiseMessageOptions
-from ignition_transport import Node
-from ignition_transport import Publisher
+from ignition.transport import AdvertiseMessageOptions
+from ignition.transport import Node
 
 # Create a transport node
 node = Node()
@@ -100,8 +99,8 @@ import typing
 
 from ignition.msgs.stringmsg_pb2 import StringMsg
 
-from ignition_transport import SubscribeOptions
-from ignition_transport import Node
+from ignition.transport import SubscribeOptions
+from ignition.transport import Node
 
 def cb(msg: StringMsg) -> None:
     print("Msg: [{}] from Python".format(msg.data))

--- a/README.md
+++ b/README.md
@@ -378,14 +378,14 @@ wget https://raw.githubusercontent.com/srmainwaring/ign-bazel/bazel-macos/exampl
 vcs import . < bazel.repos
 ```
 
-Next, symlink the following files into the workspace directory for `bazel`:
+Next, symlink the following files into the workspace directory:
 
 ```bash
 cd ~/ignition
 ln -sf ./ign_bazel/example/WORKSPACE.example ./WORKSPACE
 ln -sf ./ign_bazel/example/BUILD.example ./BUILD.bazel
 ln -sf ./ign_bazel/example/bazelrc.example ./.bazelrc
-ln -sf ./ign_bazel/example/ign-msgs9.BUILD.example ./ign-msgs9.BUILD
+ln -sf ./python_ignition/ign-msgs9.BUILD ./ign-msgs9.BUILD
 ```
 
 Finally, [`pybind11_protobuf`](https://github.com/pybind/pybind11_protobuf) requires a patch to the protobuf archive which must be available in the subdirectory `~/ignition/external`. It must be copied rather than symlinked:

--- a/ign-msgs9.BUILD
+++ b/ign-msgs9.BUILD
@@ -23,6 +23,8 @@
 load("@rules_proto_grpc//cpp:defs.bzl", "cpp_proto_library")
 load("@rules_proto_grpc//python:defs.bzl", "python_proto_library")
 
+package(default_visibility = ["//visibility:public"])
+
 #———————————————————————————————————————————————————————————————————————
 # proto_files
 
@@ -66,7 +68,6 @@ proto_library(
     ":vector3d_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -80,7 +81,6 @@ cpp_proto_library(
     ":time_cc_proto",
     ":vector3d_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -95,7 +95,6 @@ python_proto_library(
     ":vector3d_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 
@@ -108,7 +107,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -117,7 +115,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -127,7 +124,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -139,7 +135,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -148,7 +143,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -158,7 +152,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -170,7 +163,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -179,7 +171,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -189,7 +180,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -202,7 +192,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -212,7 +201,6 @@ cpp_proto_library(
     ":double_cc_proto",
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -225,7 +213,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -237,7 +224,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -246,7 +232,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -256,7 +241,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -269,7 +253,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -279,7 +262,6 @@ cpp_proto_library(
     ":float_cc_proto",
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -290,7 +272,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -300,7 +281,6 @@ proto_library(
   srcs = ["proto/ignition/msgs/header.proto"],
   deps = [":time_proto"],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -309,7 +289,6 @@ cpp_proto_library(
   deps = [
     ":time_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -319,7 +298,6 @@ python_proto_library(
     ":time_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -332,7 +310,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -342,7 +319,6 @@ cpp_proto_library(
     ":any_cc_proto",
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -353,7 +329,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -366,7 +341,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -376,7 +350,6 @@ cpp_proto_library(
     ":double_cc_proto",
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -387,7 +360,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -401,7 +373,6 @@ proto_library(
     ":vector3d_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -412,7 +383,6 @@ cpp_proto_library(
     ":quaternion_cc_proto",
     ":vector3d_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -424,7 +394,6 @@ python_proto_library(
     ":vector3d_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -437,7 +406,6 @@ proto_library(
     ":pose_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -447,7 +415,6 @@ cpp_proto_library(
     ":header_cc_proto",
     ":pose_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -458,7 +425,6 @@ python_proto_library(
     ":pose_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -470,7 +436,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -479,7 +444,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -489,7 +453,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -502,7 +465,6 @@ proto_library(
     ":publish_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -512,7 +474,6 @@ cpp_proto_library(
     ":header_cc_proto",
     ":publish_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -523,7 +484,6 @@ python_proto_library(
     ":publish_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -535,7 +495,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -544,7 +503,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -554,7 +512,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -566,7 +523,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -575,7 +531,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -585,7 +540,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -597,7 +551,6 @@ proto_library(
     ":header_proto"
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -606,7 +559,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto"
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -616,7 +568,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -625,20 +576,17 @@ proto_library(
   name = "time_proto",
   srcs = ["proto/ignition/msgs/time.proto"],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
   name = "time_cc_proto",
   protos = [":time_proto"],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
   name = "time_py_pb2",
   protos = [":time_proto"],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
  )
 
 #———————————————————————————————————————————————————————————————————————
@@ -652,7 +600,6 @@ proto_library(
     ":subscribe_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -663,7 +610,6 @@ cpp_proto_library(
     ":publish_cc_proto",
     ":subscribe_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -675,7 +621,6 @@ python_proto_library(
     ":subscribe_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -688,7 +633,6 @@ proto_library(
     ":vector3d_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -698,7 +642,6 @@ cpp_proto_library(
     ":header_cc_proto",
     ":vector3d_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -709,7 +652,6 @@ python_proto_library(
     ":vector3d_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -721,7 +663,6 @@ proto_library(
     ":header_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -730,7 +671,6 @@ cpp_proto_library(
   deps = [
     ":header_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -740,7 +680,6 @@ python_proto_library(
     ":header_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -753,7 +692,6 @@ proto_library(
     ":vector3d_proto",
   ],
   strip_import_prefix = "proto",
-  visibility = ["//visibility:public"],
 )
 
 cpp_proto_library(
@@ -763,7 +701,6 @@ cpp_proto_library(
     ":header_cc_proto",
     ":vector3d_cc_proto",
   ],
-  visibility = ["//visibility:public"],
 )
 
 python_proto_library(
@@ -774,5 +711,4 @@ python_proto_library(
     ":vector3d_py_pb2",
   ],
   output_mode = "NO_PREFIX",
-  visibility = ["//visibility:public"],
 )

--- a/include/BUILD
+++ b/include/BUILD
@@ -1,0 +1,14 @@
+#———————————————————————————————————————————————————————————————————————
+# ignition_msgs_extras_hh
+# 
+cc_library(
+  name = "ignition_msgs_extras_hdrs",
+  hdrs = ["ignition/msgs/extras.hh"],
+  includes = ["."],
+  deps = [
+    "@ign-msgs9//:time_cc_proto",
+    "@ign-msgs9//:topic_info_cc_proto",
+    "@ign-msgs9//:wrench_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/include/ignition/msgs/extras.hh
+++ b/include/ignition/msgs/extras.hh
@@ -15,19 +15,29 @@
  *
 */
 
-#include <pybind11/pybind11.h>
+#ifndef PYTHON_IGNITION_MSGS_HH
+#define PYTHON_IGNITION_MSGS_HH
 
-#include "pybind11_protobuf/native_proto_caster.h"
+#include <ignition/msgs/time.pb.h>
+#include <ignition/msgs/topic_info.pb.h>
+#include <ignition/msgs/wrench.pb.h>
 
-#include "ignition_msgs.hh"
+namespace ignition
+{
+  namespace msgs
+  {
+    namespace extras
+    {
 
-namespace py = pybind11;
+      Time MakeTime();
 
-PYBIND11_MODULE(ignition_msgs, m) {
-  pybind11_protobuf::ImportNativeProtoCasters();
+      void TakeTime(const Time& msg);
 
-  m.def("make_time", &MakeTime);
-  m.def("take_time", &TakeTime, pybind11::arg("msg"));
-  m.def("take_topic_info", &TakeTopicInfo, pybind11::arg("msg"));
-  m.def("take_wrench", &TakeWrench, pybind11::arg("msg"));
+      void TakeTopicInfo(const TopicInfo& msg);
+
+      void TakeWrench(const Wrench& msg);
+    }
+  }
 }
+
+#endif

--- a/python/BUILD
+++ b/python/BUILD
@@ -1,11 +1,33 @@
 #———————————————————————————————————————————————————————————————————————
 # Python examples
+# 
+# 
+# Notes:
+# 
+# In py_binary the flag:
+# 
+#   legacy_create_init = False
+# 
+# Because there are two `ignition` packages. One coming from @ign-msgs9
+# that contains the generated protbuf Python bindings, and the other
+# from the pybind11 extension modules. The default behaviour is for Bazel
+# to generate empty __init__.py files in all subdirectories under the
+# <py_binary.name>.runfiles directory in bazel-bin. In that case only the
+# first occurrence of `ignition` on the sys.path will be loaded and an
+# attempt to import the other package results in module not found errors.
+#
+# See the function documentation for `py_binary`: 
+# Bazel Python Rules: https://docs.bazel.build/versions/main/be/python.html
+# 
+# 
 #———————————————————————————————————————————————————————————————————————
 
+package(default_visibility = ["//visibility:public"])
+
 #———————————————————————————————————————————————————————————————————————
-# ign_msg_py_deps: list of all the generated Python protobuf libraries
+# ign_msgs_py_deps: list of all the generated Python protobuf libraries
 # 
-ign_msg_py_deps = [
+ign_msgs_py_deps = [
   "@ign-msgs9//:any_py_pb2",
   "@ign-msgs9//:color_py_pb2",
   "@ign-msgs9//:cmd_vel2d_py_pb2",
@@ -31,16 +53,23 @@ ign_msg_py_deps = [
 ]
 
 #———————————————————————————————————————————————————————————————————————
+# import_check
+# 
+py_binary(
+  name = "import_check",
+  srcs = ["import_check.py"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
+)
+
+#———————————————————————————————————————————————————————————————————————
 # msgs_example
 # 
 py_binary(
   name = "msgs_example",
   srcs = ["msgs_example.py"],
-  data = [
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps,
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -49,12 +78,8 @@ py_binary(
 py_binary(
   name = "transport_example",
   srcs = ["transport_example.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -65,12 +90,8 @@ py_binary(
 py_binary(
   name = "publisher",
   srcs = ["publisher.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -81,12 +102,8 @@ py_binary(
 py_binary(
   name = "subscriber",
   srcs = ["subscriber.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -99,11 +116,10 @@ py_binary(
   name = "rover_publisher",
   srcs = ["rover_publisher.py"],
   data = [
-    "//python_ignition:ignition_transport.so",
     "@com_google_protobuf//:proto_api",
   ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -115,12 +131,8 @@ py_binary(
 py_binary(
   name = "rover_subscriber",
   srcs = ["rover_subscriber.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -129,12 +141,8 @@ py_binary(
 py_binary(
   name = "pub_all_msg_types",
   srcs = ["pub_all_msg_types.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -145,12 +153,8 @@ py_binary(
 py_binary(
   name = "ign_topic_list",
   srcs = ["ign_topic_list.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -161,12 +165,8 @@ py_binary(
 py_binary(
   name = "ign_topic_info",
   srcs = ["ign_topic_info.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 
 #———————————————————————————————————————————————————————————————————————
@@ -177,11 +177,7 @@ py_binary(
 py_binary(
   name = "ign_topic_echo",
   srcs = ["ign_topic_echo.py"],
-  data = [
-    "//python_ignition:ignition_transport.so",
-    "@com_google_protobuf//:proto_api",
-  ],
-  deps = ign_msg_py_deps,
-  visibility = ["//visibility:public"],
+  deps = ign_msgs_py_deps + ["//python_ignition:ignition_py"],
+  legacy_create_init = False,
 )
 

--- a/python/ign_topic_echo.py
+++ b/python/ign_topic_echo.py
@@ -23,8 +23,8 @@ $ ign topic -i -e /topic
 import argparse
 import time
 
-from ignition_transport import SubscribeOptions
-from ignition_transport import Node
+from ignition.transport import SubscribeOptions
+from ignition.transport import Node
 
 # callback - prints the raw message
 def cb(msg):

--- a/python/ign_topic_info.py
+++ b/python/ign_topic_info.py
@@ -22,7 +22,7 @@ $ ign topic -i -t /topic
 
 import argparse
 
-from ignition_transport import Node
+from ignition.transport import Node
 
 def main():
     # process command line

--- a/python/ign_topic_list.py
+++ b/python/ign_topic_list.py
@@ -20,7 +20,7 @@ Replicate the ign_tools command:
 $ ign topic -l
 '''
 
-from ignition_transport import Node
+from ignition.transport import Node
 
 def main():
     # create a transport node

--- a/python/import_check.py
+++ b/python/import_check.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 
 from ignition.msgs.any_pb2 import Any
 from ignition.msgs.header_pb2 import Header
 from ignition.msgs.stringmsg_pb2 import StringMsg
+from ignition.msgs.time_pb2 import Time
 
 from ignition.msgs.extras import make_time
 from ignition.msgs.extras import take_time
@@ -30,6 +32,9 @@ from ignition.transport import Node
 
 
 def main():
+    # for item in sys.path:
+    #   print(item)
+
     # msgs
     msg = Any()
     msg = Header()

--- a/python/import_check.py
+++ b/python/import_check.py
@@ -16,38 +16,33 @@
 
 import time
 
+from ignition.msgs.any_pb2 import Any
+from ignition.msgs.header_pb2 import Header
 from ignition.msgs.stringmsg_pb2 import StringMsg
+
+from ignition.msgs.extras import make_time
+from ignition.msgs.extras import take_time
+from ignition.msgs.extras import take_topic_info
+from ignition.msgs.extras import take_wrench
 
 from ignition.transport import AdvertiseMessageOptions
 from ignition.transport import Node
 
+
 def main():
-    # Create a transport node and advertise a topic
-    node = Node()
-    topic = "/foo"
-    msg_type_name = StringMsg.DESCRIPTOR.full_name
-    pub_options = AdvertiseMessageOptions()
-    pub = node.advertise(topic, msg_type_name, pub_options)
-    if pub.valid():
-        print("Advertising {} on topic [{}]".format(msg_type_name, topic))
-    else:
-        print("Error advertising topic [{}]".format(topic))
-
-    # Prepare the message
+    # msgs
+    msg = Any()
+    msg = Header()
     msg = StringMsg()
-    msg.data = "hello"
 
-    try:
-        while True:
-          if not pub.publish(msg):
-              break
+    # msgs functions
+    msg = make_time()
 
-          print("Publishing hello on topic [{}]".format(topic))
-          time.sleep(1.0)
+    # transport types
+    opts = AdvertiseMessageOptions()
+    node = Node()
+    pub = Node.Publisher()
 
-    except KeyboardInterrupt:
-        pass
 
 if __name__ == "__main__":
     main()
-

--- a/python/pub_all_msg_types.py
+++ b/python/pub_all_msg_types.py
@@ -35,9 +35,8 @@ from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 from ignition.msgs.wrench_pb2 import Wrench
 
-from ignition_transport import AdvertiseMessageOptions
-from ignition_transport import Node
-from ignition_transport import Publisher
+from ignition.transport import AdvertiseMessageOptions
+from ignition.transport import Node
 
 def main():
     # Create a transport node and advertise options

--- a/python/rover_publisher.py
+++ b/python/rover_publisher.py
@@ -25,9 +25,8 @@ from ignition.msgs.time_pb2 import Time
 from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 
-from ignition_transport import AdvertiseMessageOptions
-from ignition_transport import Node
-from ignition_transport import Publisher
+from ignition.transport import AdvertiseMessageOptions
+from ignition.transport import Node
 
 def main():
     # Create a transport node and advertise a topic

--- a/python/rover_subscriber.py
+++ b/python/rover_subscriber.py
@@ -22,8 +22,8 @@ from ignition.msgs.quaternion_pb2 import Quaternion
 from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 
-from ignition_transport import Node
-from ignition_transport import SubscribeOptions
+from ignition.transport import Node
+from ignition.transport import SubscribeOptions
 
 
 def pose_cb(msg: Pose) -> None:

--- a/python/subscriber.py
+++ b/python/subscriber.py
@@ -19,8 +19,8 @@ import typing
 
 from ignition.msgs.stringmsg_pb2 import StringMsg
 
-from ignition_transport import SubscribeOptions
-from ignition_transport import Node
+from ignition.transport import SubscribeOptions
+from ignition.transport import Node
 
 def cb(msg: StringMsg) -> None:
     print("Msg: [{}] from Python".format(msg.data))

--- a/python/transport_example.py
+++ b/python/transport_example.py
@@ -22,10 +22,9 @@ from ignition.msgs.twist_pb2 import Twist
 from ignition.msgs.vector3d_pb2 import Vector3d
 from ignition.msgs.wrench_pb2 import Wrench
 
-from ignition_transport import AdvertiseMessageOptions
-from ignition_transport import SubscribeOptions
-from ignition_transport import Node
-from ignition_transport import Publisher
+from ignition.transport import AdvertiseMessageOptions
+from ignition.transport import SubscribeOptions
+from ignition.transport import Node
 
 from google.protobuf.internal import api_implementation
 
@@ -42,7 +41,7 @@ def main():
 
     #----------------------------------------------
     # get a publisher and check valid
-    pub = Publisher()
+    pub = Node.Publisher()
     print("publisher valid: {}".format(pub.valid()))
 
     # create and publish different message types

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,9 +18,9 @@
 #include <iostream>
 #include <string>
 
-#include "ignition/msgs/time.pb.h"
+#include <ignition/msgs/time.pb.h>
 
-#include "ignition_msgs.hh"
+#include "ignition/msgs/extras.hh"
 
 int main(int argc, const char* argv[])
 {
@@ -28,7 +28,7 @@ int main(int argc, const char* argv[])
   // compatible with the version used to generate the headers.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  std::cout << "Ignition Msgs Example" << std::endl;
+  std::cout << "Ignition MsgsExtras Example" << std::endl;
 
   // example: ignition/msgs/time.proto
   {
@@ -40,8 +40,8 @@ int main(int argc, const char* argv[])
 
   // example: msgs_tools
   {
-    auto msg = MakeTime();
-    TakeTime(msg);
+    auto msg = ignition::msgs::extras::MakeTime();
+    ignition::msgs::extras::TakeTime(msg);
   }
 
   // Shutdown

--- a/src/pybind11/ignition/BUILD
+++ b/src/pybind11/ignition/BUILD
@@ -1,0 +1,23 @@
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+  name = "foo_py",
+  srcs = ["foo.py"],
+)
+
+#———————————————————————————————————————————————————————————————————————
+# ignition.transport
+# 
+# Python bindings for ignition transport
+
+pybind_extension(
+  name = "transport",
+  srcs = ["transport/_ignition_transport_pybind11.cc"],
+  deps = [
+    "//ign_transport:ign_transport",
+    "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+    "@com_google_protobuf//:protobuf",
+  ],
+)

--- a/src/pybind11/ignition/msgs/BUILD
+++ b/src/pybind11/ignition/msgs/BUILD
@@ -1,0 +1,36 @@
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+
+package(default_visibility = ["//visibility:public"])
+
+#———————————————————————————————————————————————————————————————————————
+# ignition_msgs_extras_lib
+#
+# TODO(srmainwaring) could move this back up to project root. 
+# 
+cc_library(
+  name = "ignition_msgs_extras_lib",
+  srcs = ["extras.cc"],
+  deps = [
+    "//python_ignition/include:ignition_msgs_extras_hdrs",
+    "@ign-msgs9//:time_cc_proto",
+    "@ign-msgs9//:topic_info_cc_proto",
+    "@ign-msgs9//:wrench_cc_proto",
+  ],
+)
+
+#———————————————————————————————————————————————————————————————————————
+# ignition.msgs.extra
+# 
+# Python bindings for ignition msgs extras
+
+pybind_extension(
+  name = "extras",
+  srcs = ["_ignition_msgs_extras_pybind11.cc"],
+  deps = [
+    ":ignition_msgs_extras_lib",
+    "//python_ignition/include:ignition_msgs_extras_hdrs",
+    "//ign_transport:ign_transport",
+    "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+    "@com_google_protobuf//:protobuf",
+  ],
+)

--- a/src/pybind11/ignition/msgs/_ignition_msgs_extras_pybind11.cc
+++ b/src/pybind11/ignition/msgs/_ignition_msgs_extras_pybind11.cc
@@ -19,7 +19,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <pybind11_protobuf/native_proto_caster.h>
+#include "pybind11_protobuf/native_proto_caster.h"
 
 namespace py = pybind11;
 

--- a/src/pybind11/ignition/msgs/_ignition_msgs_extras_pybind11.cc
+++ b/src/pybind11/ignition/msgs/_ignition_msgs_extras_pybind11.cc
@@ -15,19 +15,26 @@
  *
 */
 
-#ifndef PYTHON_IGNITION_MSGS_HH
-#define PYTHON_IGNITION_MSGS_HH
+#include "ignition/msgs/extras.hh"
 
-#include "ignition/msgs/time.pb.h"
-#include "ignition/msgs/topic_info.pb.h"
-#include "ignition/msgs/wrench.pb.h"
+#include <pybind11/pybind11.h>
 
-ignition::msgs::Time MakeTime();
+#include <pybind11_protobuf/native_proto_caster.h>
 
-void TakeTime(const ignition::msgs::Time& msg);
+namespace py = pybind11;
 
-void TakeTopicInfo(const ignition::msgs::TopicInfo& msg);
+PYBIND11_MODULE(extras, m)
+{
+  using namespace ignition;
+  using namespace msgs;
+  using namespace extras;
 
-void TakeWrench(const ignition::msgs::Wrench& msg);
+  pybind11_protobuf::ImportNativeProtoCasters();
 
-#endif
+  m.doc() = "Ignition Msgs Extras Python Library.";
+
+  m.def("make_time", &MakeTime);
+  m.def("take_time", &TakeTime, pybind11::arg("msg"));
+  m.def("take_topic_info", &TakeTopicInfo, pybind11::arg("msg"));
+  m.def("take_wrench", &TakeWrench, pybind11::arg("msg"));
+}

--- a/src/pybind11/ignition/msgs/extras.cc
+++ b/src/pybind11/ignition/msgs/extras.cc
@@ -15,27 +15,36 @@
  *
 */
 
-#include "ignition_msgs.hh"
+#include "ignition/msgs/extras.hh"
 
-ignition::msgs::Time MakeTime()
+namespace ignition
 {
-  ignition::msgs::Time msg;
-  msg.set_sec(10);
-  msg.set_nsec(20);
-  return msg;
-}
+  namespace msgs
+  {
+    namespace extras
+    {
+      Time MakeTime()
+      {
+        Time msg;
+        msg.set_sec(10);
+        msg.set_nsec(20);
+        return msg;
+      }
 
-void TakeTime(const ignition::msgs::Time& msg)
-{
-  std::cout << msg.DebugString();
-}
+      void TakeTime(const Time& msg)
+      {
+        std::cout << msg.DebugString();
+      }
 
-void TakeTopicInfo(const ignition::msgs::TopicInfo& msg)
-{
-  std::cout << msg.DebugString();
-}
+      void TakeTopicInfo(const TopicInfo& msg)
+      {
+        std::cout << msg.DebugString();
+      }
 
-void TakeWrench(const ignition::msgs::Wrench& msg)
-{
-  std::cout << msg.DebugString();
+      void TakeWrench(const Wrench& msg)
+      {
+        std::cout << msg.DebugString();
+      }
+    }
+  }
 }

--- a/src/pybind11/ignition/transport/_ignition_transport_pybind11.cc
+++ b/src/pybind11/ignition/transport/_ignition_transport_pybind11.cc
@@ -22,7 +22,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
-#include <pybind11_protobuf/native_proto_caster.h>
+#include "pybind11_protobuf/native_proto_caster.h"
 
 #include <google/protobuf/message.h>
 


### PR DESCRIPTION
This PR restructures the pybind11 extension modules to better align with the conventions used in `ign-gazebo`

## Interface changes

These changes alter the Python interface at the top level of import.

The import for `ign-transport` was

```python
from ignition_transport import Node
```

and is now

```python
from ignition.transport import Node
```

The example module for messages was

```python
from ignition_msgs import make_time
```

and is now

```python
from ignition.msgs.extras import make_time
```

The protobuf bindings are unchanged.

## Bazel build changes

The Bazel build has been overhauled so that the extension modules are organised into the correct hierarchy. The Python examples will now run without any need to set the PYTHONPATH or modify the import prefix.





  