### PR TITLE
Add bindings for services

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,7 +33,7 @@ cc_binary(
   deps = [
     "//ign_utils:ign_utils",
     "//ign_math:ign_math",
-    "//ign_math:libignition-math6.so",
+    "//ign_math:libignition-math7.so",
     "@tinyxml2",
     "@sqlite3",
     "@zmq",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
-project(protobuf_example)
+project(python-ignition)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -336,7 +336,30 @@ data: "hello"
 data: "hello"
 
 data: "hello"
+```
 
+--- 
+
+`python/ign_service_list.py` is a Python version of the command `ign service -l`
+
+```bash
+$ ./python/ign_service_list.py 
+/gazebo/resource_paths/add
+/gazebo/resource_paths/get
+/gazebo/worlds
+/gui/camera/view_control
+/gui/follow
+...
+```
+
+--- 
+
+`python/ign_service_info.py` is a Python version of the command `ign service -i -s /gazebo/worlds`
+
+```bash
+$ ./python/ign_service_info.py -s /gazebo/worlds
+Service providers [Address, Request Message Type, Response Message Type]:
+  tcp://127.0.0.1:63657, ignition.msgs.Empty, ignition.msgs.StringMsg_V
 ```
 
 

--- a/python/ign_service_info.py
+++ b/python/ign_service_info.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2022 Rhys Mainwaring
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Replicate the ign_tools command:
+
+$ ign service -i -s /service
+'''
+
+import argparse
+
+from ignition.transport import Node
+
+def main():
+    # process command line
+    parser = argparse.ArgumentParser(description="Get info about a service.")
+    parser.add_argument("-s", "--service",
+        metavar="service", required=True, help="Name of a service")
+    args = parser.parse_args()
+
+    # service is required
+    service = args.service
+
+    # create a transport node
+    node = Node()
+
+    # get list of service info
+    service_info_list = node.service_info(service)
+
+    # display address and message types
+    print("Service providers [Address, Request Message Type, Response Message Type]:")
+    for service_info in service_info_list:
+        print("  {}, {}, {}".format(
+            service_info.addr,
+            service_info.req_type_name,
+            service_info.rep_type_name))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/python/ign_service_list.py
+++ b/python/ign_service_list.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2022 Rhys Mainwaring
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Replicate the ign_tools command:
+
+$ ign service -l
+'''
+
+from ignition.transport import Node
+
+def main():
+    # create a transport node
+    node = Node()
+
+    # get list of services
+    service_list = node.service_list()
+    for service in service_list:
+        print(service)
+
+if __name__ == "__main__":
+    main()
+

--- a/src/pybind11/ignition/transport/_ignition_transport_pybind11.cc
+++ b/src/pybind11/ignition/transport/_ignition_transport_pybind11.cc
@@ -44,64 +44,88 @@ void define_transport_node(py::module_ module)
 
   pybind11_protobuf::ImportNativeProtoCasters();
 
-  py::enum_<Scope_t>(module, "Scope_t")
-    .value("PROCESS", Scope_t::PROCESS)
-    .value("HOST", Scope_t::HOST)
-    .value("ALL", Scope_t::ALL)
-    ;
+  py::enum_<Scope_t>(module, "Scope_t",
+      "Defines the different options for the scope of a topic/service")
+      .value("PROCESS", Scope_t::PROCESS,
+          "Topic/service only available to subscribers in the"
+          " same process as the publisher")
+      .value("HOST", Scope_t::HOST,
+          "Topic/service only available to subscribers in the"
+          " same machine as the publisher")
+      .value("ALL", Scope_t::ALL,
+          "Topic/service available to any subscriber (default scope)")
+      ;
 
   py::class_<AdvertiseOptions>(
-      module, "AdvertiseOptions")
+      module, "AdvertiseOptions",
+      "A class for customizing the publication options for"
+      " a topic or service advertised")
       .def(py::init<>())
       .def_property("scope",
           &AdvertiseOptions::Scope,
-          &AdvertiseOptions::SetScope)
+          &AdvertiseOptions::SetScope,
+          "The scope used in this topic/service")
       ;
 
   py::class_<AdvertiseMessageOptions, AdvertiseOptions>(
-      module, "AdvertiseMessageOptions")
+      module, "AdvertiseMessageOptions",
+      "A class for customizing the publication options for a topic")
       .def(py::init<>())
       .def_property_readonly("throttled",
-          &AdvertiseMessageOptions::Throttled)
+          &AdvertiseMessageOptions::Throttled,
+          "Whether the publication has been throttled")
       .def_property("msgs_per_sec",
           &AdvertiseMessageOptions::MsgsPerSec,
-          &AdvertiseMessageOptions::SetMsgsPerSec)
+          &AdvertiseMessageOptions::SetMsgsPerSec,
+          "The maximum number of messages per second to be published")
       ;
 
   py::class_<AdvertiseServiceOptions, AdvertiseOptions>(
-      module, "AdvertiseServiceOptions")
+      module, "AdvertiseServiceOptions",
+      "A class for customizing the publication options for a service")
       .def(py::init<>())
       ;
 
   py::class_<SubscribeOptions>(
-      module, "SubscribeOptions")
+      module, "SubscribeOptions",
+      "A class to provide different options for a subscription")
       .def(py::init<>())
       .def_property_readonly("throttled",
-          &SubscribeOptions::Throttled)
+          &SubscribeOptions::Throttled,
+          "Whether the subscription has been throttled")
       .def_property("msgs_per_sec",
           &SubscribeOptions::MsgsPerSec,
-          &SubscribeOptions::SetMsgsPerSec)
+          &SubscribeOptions::SetMsgsPerSec,
+          "Set the maximum number of messages per second received per topic")
       ;
 
   py::class_<Publisher>(
-      module, "Publisher")
+      module, "Publisher",
+      "This class stores all the information about a publisher."
+      " It stores the topic name that publishes, addresses,"
+      " UUIDs, scope, etc.")
       .def(py::init<>())
       .def_property("topic",
           &Publisher::Topic,
-          &Publisher::SetTopic)
+          &Publisher::SetTopic,
+          "The topic published by this publisher")
       .def_property("addr",
           &Publisher::Addr,
-          &Publisher::SetAddr)
+          &Publisher::SetAddr,
+          "Get the ZeroMQ address of the publisher")
       .def_property("puuid",
           &Publisher::PUuid,
-          &Publisher::SetPUuid)
+          &Publisher::SetPUuid,
+          "The process UUID of the publisher")
       .def_property("nuuid",
           &Publisher::NUuid,
-          &Publisher::SetNUuid)
+          &Publisher::SetNUuid,
+          "Get the node UUID of the publisher")
       // virtual
       .def_property("options",
           &Publisher::Options,
-          &Publisher::SetOptions)
+          &Publisher::SetOptions,
+          "Get the advertised options")
       // virtual
       .def("discovery", [](
           Publisher &_pub)
@@ -109,22 +133,28 @@ void define_transport_node(py::module_ module)
             ignition::msgs::Discovery msg;
             _pub.FillDiscovery(msg);
             return msg;
-          })
+          },
+          "Populate a discovery message")
       ;
 
   py::class_<MessagePublisher, Publisher>(
-      module, "MessagePublisher")
+      module, "MessagePublisher",
+      "This class stores all the information about a message publisher")
       .def(py::init<>())
       .def_property("ctrl",
           &MessagePublisher::Ctrl,
-          &MessagePublisher::SetCtrl)
+          &MessagePublisher::SetCtrl,
+          "The ZeroMQ control address. This address is used by the"
+          " subscribers to notify the publisher about the new subscription")
       .def_property("msg_type_name",
           &MessagePublisher::MsgTypeName,
-          &MessagePublisher::SetMsgTypeName)
+          &MessagePublisher::SetMsgTypeName,
+          "Get the message type advertised by this publisher")
       // virtual
       .def_property("options",
           &MessagePublisher::Options,
-          &MessagePublisher::SetOptions)
+          &MessagePublisher::SetOptions,
+          "The advertised options")
       // virtual
       .def("discovery", [](
           MessagePublisher &_pub)
@@ -132,25 +162,31 @@ void define_transport_node(py::module_ module)
             ignition::msgs::Discovery msg;
             _pub.FillDiscovery(msg);
             return msg;
-          })
+          },
+          "Populate a discovery message")
       ;
 
   py::class_<ServicePublisher, Publisher>(
-      module, "ServicePublisher")
+      module, "ServicePublisher",
+      "This class stores all the information about a service publisher")
       .def(py::init<>())
       .def_property("socket_id",
           &ServicePublisher::SocketId,
-          &ServicePublisher::SetSocketId)
+          &ServicePublisher::SetSocketId,
+          "The ZeroMQ socket ID for this publisher")
       .def_property("req_type_name",
           &ServicePublisher::ReqTypeName,
-          &ServicePublisher::SetReqTypeName)
+          &ServicePublisher::SetReqTypeName,
+          "The name of the request's protobuf message advertised")
       .def_property("rep_type_name",
           &ServicePublisher::RepTypeName,
-          &ServicePublisher::SetRepTypeName)
+          &ServicePublisher::SetRepTypeName,
+          "The name of the response's protobuf message advertised")
       // virtual
       .def_property("options",
           &ServicePublisher::Options,
-          &ServicePublisher::SetOptions)
+          &ServicePublisher::SetOptions,
+          "The advertised options")
       // virtual
       .def("discovery", [](
           ServicePublisher &_pub)
@@ -158,10 +194,14 @@ void define_transport_node(py::module_ module)
             ignition::msgs::Discovery msg;
             _pub.FillDiscovery(msg);
             return msg;
-          })
+          },
+          "Populate a discovery message")
       ;
 
-  auto node = py::class_<Node>(module, "Node")
+  auto node = py::class_<Node>(module, "Node",
+      "A class that allows a client to communicate with other peers."
+      " There are two main communication modes: pub/sub messages"
+      " and service calls")
       .def(py::init<>())
       .def("advertise", static_cast<
           Node::Publisher (Node::*) (
@@ -171,8 +211,11 @@ void define_transport_node(py::module_ module)
           )>(&Node::Advertise),
           pybind11::arg("topic"),
           pybind11::arg("msg_type_name"),
-          pybind11::arg("options"))
-      .def("advertised_topics", &Node::AdvertisedTopics)
+          pybind11::arg("options"),
+          "Advertise a new topic. If a topic is currently advertised,"
+          " you cannot advertise it a second time (regardless of its type)")
+      .def("advertised_topics", &Node::AdvertisedTopics,
+          "Get the list of topics advertised by this node")
       .def("subscribe", [](
           Node &_node,
           const std::string &_topic,
@@ -185,17 +228,21 @@ void define_transport_node(py::module_ module)
           pybind11::arg("topic"),
           pybind11::arg("callback"),
           pybind11::arg("msg_type_name"),
-          pybind11::arg("options"))
-      .def("subscribed_topics", &Node::SubscribedTopics)
+          pybind11::arg("options"),
+          "Subscribe to a topic registering a callback")
+      .def("subscribed_topics", &Node::SubscribedTopics,
+          "Get the list of topics subscribed by this node")
       .def("unsubscribe", &Node::Unsubscribe,
-          pybind11::arg("topic"))
+          pybind11::arg("topic"),
+          "Unsubscribe from a topic")
       .def("topic_list", [](
           Node &_node)
           {
             std::vector<std::string> topics;
             _node.TopicList(topics);
             return topics;
-          })
+          },
+          "Get the list of topics currently advertised in the network")
       .def("topic_info", [](
           Node &_node,
           const std::string &_topic)
@@ -204,8 +251,10 @@ void define_transport_node(py::module_ module)
             _node.TopicInfo(_topic, publishers);
             return publishers;
           },
-          pybind11::arg("topic"))
-      .def("advertised_services", &Node::AdvertisedServices)
+          pybind11::arg("topic"),
+          "Get the information about a topic")
+      .def("advertised_services", &Node::AdvertisedServices,
+          "Get the list of services advertised by this node")
       // send a service request using the blocking interface
       .def("request", [](
           Node &_node,
@@ -229,14 +278,17 @@ void define_transport_node(py::module_ module)
           pybind11::arg("service"),
           pybind11::arg("request"),
           pybind11::arg("timeout"),
-          pybind11::arg("rep_type_name"))
+          pybind11::arg("rep_type_name"),
+          "Request a new service without input parameter using"
+          " a blocking call")
       .def("service_list", [](
           Node &_node)
           {
             std::vector<std::string> services;
             _node.ServiceList(services);
             return services;
-          })
+          },
+          "Get the list of topics currently advertised in the network")
       .def("service_info", [](
           Node &_node,
           const std::string &_service)
@@ -245,19 +297,27 @@ void define_transport_node(py::module_ module)
             _node.ServiceInfo(_service, publishers);
             return publishers;
           },
-          pybind11::arg("service"))
+          pybind11::arg("service"),
+          "Get the information about a service")
       ;
 
   // register Node::Publisher as a subclass of Node
-  py::class_<ignition::transport::Node::Publisher>(node, "Publisher")
+  py::class_<ignition::transport::Node::Publisher>(node, "Publisher",
+      "A class that is used to store information about an"
+      " advertised publisher.")
       .def(py::init<>())
-      .def("valid", &ignition::transport::Node::Publisher::Valid)
+      .def("valid", &ignition::transport::Node::Publisher::Valid,
+          "Return true if valid information, such as a non-empty"
+          " topic name, is present.")
       .def("publish", &ignition::transport::Node::Publisher::Publish,
-          pybind11::arg("msg"))
+          pybind11::arg("msg"),
+          "Publish a message")
       .def("throttled_update_ready",
-          &ignition::transport::Node::Publisher::ThrottledUpdateReady)
+          &ignition::transport::Node::Publisher::ThrottledUpdateReady,
+          "")
       .def("has_connections",
-          &ignition::transport::Node::Publisher::HasConnections)
+          &ignition::transport::Node::Publisher::HasConnections,
+          "Return true if this publisher has subscribers")
       ;
 }
 }


### PR DESCRIPTION
This PR adds bindings for some of the ignition-transport service functions

- List services
- Provide service info
- Call a service with a blocking request 

There are also some other maintenance changes

- Rename the cmake project to python-ignition so it appears correctly in `colcon graph`
- Update dependency on math to ignition-math7 (garden)
- Update README with examples
- Add docstrings to the bound functions and classes
- Add bindings for dependencies (`AdvertiseOptions` and `ServicePublisher` etc.)