### PR TITLE
Support more than one version of Ignition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(python-ignition)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT APPLE)
+  set(CMAKE_CXX_FLAGS "-fPIC")
+endif()
+
 #============================================================================
 # Find protobuf
 # 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,28 @@ find_package(Python COMPONENTS Interpreter Development)
 # find_package(pybind11 CONFIG)
 
 #============================================================================
-# Find the ign-msgs library
-set(IGN_MSGS_VER 9)
-find_package(ignition-msgs${IGN_MSGS_VER} REQUIRED)
+# Find Ignition dependencies
 
-# Find the ign-transport library
+# Default versions to Ignition Garden
+set(IGN_MSGS_VER 9)
 set(IGN_TRANSPORT_VER 12)
+
+if("$ENV{IGNITION_VERSION}" STREQUAL "edifice")
+  # Edifice
+  set(IGN_MSGS_VER 7)
+  set(IGN_TRANSPORT_VER 10)
+  message(STATUS "Compiling against Ignition Edifice")
+elseif("$ENV{IGNITION_VERSION}" STREQUAL "fortress")
+  # Fortress
+  set(IGN_MSGS_VER 8)
+  set(IGN_TRANSPORT_VER 11)
+  message(STATUS "Compiling against Ignition Fortress")
+else() 
+  # Default to Garden
+  message(STATUS "Compiling against Ignition Garden")
+endif()
+
+find_package(ignition-msgs${IGN_MSGS_VER} REQUIRED)
 find_package(ignition-transport${IGN_TRANSPORT_VER} REQUIRED)
 
 #============================================================================

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project provides Python bindings for [`ignition-msgs`](https://github.com/i
 ### Install Ignition
 
 Follow the installation instructions for [Ignition Garden](https://ignitionrobotics.org/docs/garden).
-This project depends on `ignition-msgs9` and `ignition-transport12`. These may be either available as system installs or in a source install in a local workspace folder which we assume is `~/workspace`.
+This project depends directly on [`ignition-msgs`](https://github.com/ignitionrobotics/ign-msgs) and [`ignition-transport`](https://github.com/ignitionrobotics/ign-transport). These may be either available as system installs or in a source install in a local workspace folder which we assume is `~/workspace`.
 
 ### Install `python-ignition`
 
@@ -24,6 +24,12 @@ Currently our use of [`pybind11_protobuf`](https://github.com/pybind/pybind11_pr
 
 ```bash
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+```
+
+Set the environment variable determing the Ignition version. This should be one of `edifice`, `fortress` or `garden`. The default is `garden`:
+
+```bash
+export IGNITION_VERSION=garden
 ```
 
 Then create a build directory, configure and make:


### PR DESCRIPTION
This PR adds support for more than one version of Ignition

Use the approach taken in ign-rviz which introduces the environment variable IGNITION_VERSION to set the Ignition release and determine which versions of ignition libraries to use.

There is also an update to the pybind11_protobuf submodule that support builds on Linux/Ubuntu.