### PR TITLE
Update build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,12 @@ project(gz-python)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT APPLE)
-  set(CMAKE_CXX_FLAGS "-fPIC")
-endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #============================================================================
 # Options
-option(BUILD_protobuf "Build protobuf Library" ON)
-message(STATUS "Build protobuf: ${BUILD_protobuf}")
 
-option(BUILD_pybind11_protobuf "Build pybind11_protobuf Library" ON)
-message(STATUS "Build pybind11_protobuf: ${BUILD_pybind11_protobuf}")
+option(BUILD_TESTS "Build tests." OFF)
 
 #============================================================================
 # Find Python
@@ -46,10 +41,17 @@ find_package(gz-transport${GZ_TRANSPORT_VER} REQUIRED)
 
 #============================================================================
 # Build dependencies
+
+set(_protobuf_repository "https://github.com/protocolbuffers/protobuf.git")
+set(_protobuf_version 21.5)
+set(_protobuf_tag v21.5)
+
+set(_pybind11_protobuf_repository "https://github.com/pybind/pybind11_protobuf.git")
+set(_pybind11_protobuf_version 0.0.0)
+set(_pybind11_protobuf_tag main)
+
 add_subdirectory(cmake/dependencies dependencies)
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR}/dependencies/install)
-
-include(deps)
 
 message("pybind11_protobuf_FOUND: ${pybind11_protobuf_FOUND}")
 message("pybind11_protobuf_SOURCE_DIR: ${pybind11_protobuf_SOURCE_DIR}")

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -3,36 +3,38 @@ include(FetchContent)
 #============================================================================
 # Declare all dependencies first
 
-if(BUILD_protobuf)
+find_package(Protobuf ${_protobuf_version} EXACT QUIET)
+if(NOT Protobuf_FOUND)
   set(protobuf_BUILD_TESTS OFF CACHE INTERNAL "")
   FetchContent_Declare(
-    protobuf
-    GIT_REPOSITORY "https://github.com/protocolbuffers/protobuf.git"
-    GIT_TAG "v21.5"
+    Protobuf
+    GIT_REPOSITORY ${_protobuf_repository}
+    GIT_TAG ${_protobuf_tag}
     GIT_SUBMODULES ""
   )
 endif()
 
-if(BUILD_pybind11_protobuf)
+find_package(pybind11_protobuf ${_pybind11_protobuf_version} EXACT QUIET)
+if(NOT pybind11_protobuf_FOUND)
   FetchContent_Declare(
     pybind11_protobuf
-    GIT_REPOSITORY "https://github.com/srmainwaring/pybind11_protobuf"
-    GIT_TAG "eea7c8e839bbcd624d8a8230773829cd49e41cba"
+    GIT_REPOSITORY ${_pybind11_protobuf_repository}
+    GIT_TAG ${_pybind11_protobuf_tag}
   )
 endif()
 
 #============================================================================
 # Make dependencies avaialble
 
-if(BUILD_protobuf)
-  message(CHECK_START "Fetching protobuf")
+if(NOT Protobuf_FOUND)
+  message(CHECK_START "Fetching Protobuf")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
-  FetchContent_MakeAvailable(protobuf)
+  FetchContent_MakeAvailable(Protobuf)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
   message(CHECK_PASS "fetched")
 endif()
 
-if(BUILD_pybind11_protobuf)
+if(NOT pybind11_protobuf_FOUND)
   message(CHECK_START "Fetching pybind11_protobuf")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
   FetchContent_MakeAvailable(pybind11_protobuf)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -1,8 +1,0 @@
-if(NOT BUILD_protobuf)
-  find_package(protobuf REQUIRED)
-endif()
-
-if(NOT BUILD_pybind11_protobuf)
-  find_package(pybind11_protobuf REQUIRED)
-endif()
-


### PR DESCRIPTION
This PR updates the build dependencies to use the `main` branch of `pybind11_protobuf` following:

- https://github.com/pybind/pybind11_protobuf/pull/73
- https://github.com/pybind/pybind11_protobuf/pull/108
-  https://github.com/pybind/pybind11_protobuf/commit/fc850638a80bf433d1c64cbfb38c2a64e40d7c3c


## Details

- Move global dependency settings to top level CMakeLists.txt.
- Remove options to build dependencies.
- Add option to build tests (placeholder).
- Only FetchContent if find_package fails.
- Update tag for dependency pybind11_protobuf to `main`.